### PR TITLE
Recommended-rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "plugin:jsdoc/recommended-typescript",
     ],
     "ignorePatterns": ["/*", "!/src"],
     "parser": "@typescript-eslint/parser",
@@ -14,78 +15,11 @@ module.exports = {
         "sourceType": "module"
     },
     "plugins": [
-        "eslint-plugin-jsdoc",
-        "eslint-plugin-prefer-arrow",
         "@typescript-eslint",
         "jsdoc"
     ],
     "root": true,
     "rules": {
-        "@typescript-eslint/adjacent-overload-signatures": "error",
-        "@typescript-eslint/array-type": [
-            "error",
-            {
-                "default": "array"
-            }
-        ],
-        "@typescript-eslint/ban-ts-comment": "error",
-        "@typescript-eslint/ban-types": "error",
-        "@typescript-eslint/indent": "off",
-        "@typescript-eslint/member-delimiter-style": [
-            "error",
-            {
-                "multiline": {
-                    "delimiter": "semi",
-                    "requireLast": true
-                },
-                "singleline": {
-                    "delimiter": "semi",
-                    "requireLast": false
-                }
-            }
-        ],
-        "@typescript-eslint/naming-convention": "error",
-        "@typescript-eslint/no-array-constructor": "error",
-        "@typescript-eslint/no-duplicate-enum-values": "error",
-        "@typescript-eslint/no-explicit-any": "error",
-        "@typescript-eslint/no-extra-non-null-assertion": "error",
-        "@typescript-eslint/no-loss-of-precision": "error",
-        "@typescript-eslint/no-misused-new": "error",
-        "@typescript-eslint/no-namespace": "error",
-        "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
-        "@typescript-eslint/no-this-alias": "error",
-        "@typescript-eslint/no-unnecessary-type-constraint": "error",
-        "@typescript-eslint/no-unsafe-declaration-merging": "error",
-        "@typescript-eslint/no-unused-expressions": "error",
-        "@typescript-eslint/no-unused-vars": "error",
-        "@typescript-eslint/no-var-requires": "warn",
-        "@typescript-eslint/prefer-as-const": "error",
-        "@typescript-eslint/prefer-for-of": "error",
-        "@typescript-eslint/quotes": [
-            "error",
-            "double",
-            {
-                "avoidEscape": true
-            }
-        ],
-        "@typescript-eslint/semi": [
-            "error",
-            "always"
-        ],
-        "@typescript-eslint/triple-slash-reference": "error",
-        "arrow-parens": [
-            "error",
-            "always"
-        ],
-        "constructor-super": "error",
-        "curly": "error",
-        "eqeqeq": [
-            "error",
-            "always"
-        ],
-        "for-direction": "error",
-        "getter-return": "error",
-        "indent": "off",
         "jsdoc/require-jsdoc": [
             "error",
             {
@@ -94,97 +28,6 @@ module.exports = {
                     "MethodDefinition": true
                 }
             }
-        ],
-        "jsdoc/check-alignment": "error",
-        "jsdoc/check-indentation": "error",
-        "jsdoc/newline-after-description": "off",
-        "new-parens": "error",
-        "no-array-constructor": "off",
-        "no-async-promise-executor": "error",
-        "no-case-declarations": "error",
-        "no-class-assign": "error",
-        "no-compare-neg-zero": "error",
-        "no-cond-assign": "error",
-        "no-const-assign": "error",
-        "no-constant-condition": "error",
-        "no-control-regex": "error",
-        "no-debugger": "error",
-        "no-delete-var": "error",
-        "no-dupe-args": "error",
-        "no-dupe-class-members": "error",
-        "no-dupe-else-if": "error",
-        "no-dupe-keys": "error",
-        "no-duplicate-case": "error",
-        "no-empty": "error",
-        "no-empty-character-class": "error",
-        "no-empty-pattern": "error",
-        "no-ex-assign": "error",
-        "no-extra-boolean-cast": "error",
-        "no-extra-semi": "error",
-        "no-fallthrough": "error",
-        "no-func-assign": "error",
-        "no-global-assign": "error",
-        "no-import-assign": "error",
-        "no-inner-declarations": "error",
-        "no-invalid-regexp": "error",
-        "no-irregular-whitespace": "error",
-        "no-loss-of-precision": "off",
-        "no-misleading-character-class": "error",
-        "no-mixed-spaces-and-tabs": "error",
-        "no-new-symbol": "error",
-        "no-nonoctal-decimal-escape": "error",
-        "no-obj-calls": "error",
-        "no-octal": "error",
-        "no-prototype-builtins": "warn",
-        "no-redeclare": "error",
-        "no-regex-spaces": "error",
-        "no-self-assign": "error",
-        "no-setter-return": "error",
-        "no-shadow-restricted-names": "error",
-        "no-sparse-arrays": "error",
-        "no-this-before-super": "error",
-        "no-trailing-spaces": "error",
-        "no-undef": "error",
-        "no-unexpected-multiline": "error",
-        "no-unreachable": "error",
-        "no-unsafe-finally": "error",
-        "no-unsafe-negation": "error",
-        "no-unsafe-optional-chaining": "error",
-        "no-unused-expressions": "off",
-        "no-unused-labels": "error",
-        "no-unused-vars": "off",
-        "no-useless-backreference": "error",
-        "no-useless-catch": "error",
-        "no-useless-escape": "error",
-        "no-var": "error",
-        "no-with": "error",
-        "prefer-arrow/prefer-arrow-functions": [
-            "error",
-            {
-                "allowStandaloneDeclarations": true
-            }
-        ],
-        "quotes": "off",
-        "require-yield": "error",
-        "semi": "off",
-        "space-before-function-paren": [
-            "error",
-            {
-                "anonymous": "always",
-                "named": "never"
-            }
-        ],
-        "spaced-comment": [
-            "error",
-            "always",
-            {
-                "markers": [
-                    "/"
-                ]
-            }
-        ],
-        "use-isnan": "error",
-        "valid-typeof": "error"
-
+        ]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         "jsdoc/require-jsdoc": [
             "error",
             {
+                "publicOnly": true,
                 "require": {
                     "FunctionDeclaration": true,
                     "MethodDefinition": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
 				"@vscode/vsce": "^2.23.0",
 				"eslint": "^8.56.0",
 				"eslint-plugin-jsdoc": "^48.1.0",
-				"eslint-plugin-prefer-arrow": "^1.2.3",
 				"rimraf": "^4.4.1",
 				"ts-loader": "^9.2.2",
 				"typescript": "^5.3.3",
@@ -2601,15 +2600,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-prefer-arrow": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-			"integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-			"dev": true,
-			"peerDependencies": {
-				"eslint": ">=2.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -591,7 +591,6 @@
 		"@vscode/vsce": "^2.23.0",
 		"eslint": "^8.56.0",
 		"eslint-plugin-jsdoc": "^48.1.0",
-		"eslint-plugin-prefer-arrow": "^1.2.3",
 		"rimraf": "^4.4.1",
 		"ts-loader": "^9.2.2",
 		"typescript": "^5.3.3",


### PR DESCRIPTION
Reduces enabled ESLint rules to just the rules from the following rulesets.

eslint:recommended
@typescript-eslint/recommended
jsdoc/recommended-typescript

This results in remaining problems.

```
✖ 644 problems (316 errors, 328 warnings)
  216 errors and 40 warnings potentially fixable with the `--fix` option.
```

## Next Steps

These rules can be fixed automatically.  I'll submit PRs for these one at a time.

@typescript-eslint/ban-types
jsdoc/require-jsdoc
jsdoc/require-param
jsdoc/tag-lines
no-useless-escape
prefer-const
no-prototype-builtins

These rules can't be fixed automatically.  We can fix these as we work in a file.

@typescript-eslint/no-explicit-any
@typescript-eslint/no-namespace
@typescript-eslint/no-unused-vars
@typescript-eslint/no-var-requires
jsdoc/check-param-names
jsdoc/check-tag-names
jsdoc/require-param-description
jsdoc/require-returns
no-cond-assign
no-inner-declarations

## Risk

No risk.  This PR only effects development.  No code changes.