### PR TITLE
Use fast textdocument for caching

### DIFF
--- a/src/features/cachedEntities.ts
+++ b/src/features/cachedEntities.ts
@@ -1,5 +1,6 @@
 
 import { CancellationToken, ProgressLocation, TextDocument, Uri, window, workspace, WorkspaceConfiguration } from "vscode";
+import { LSTextDocument } from "../utils/LSTextDocument";
 import { Component, ComponentsByName, ComponentsByUri, COMPONENT_EXT, COMPONENT_FILE_GLOB, parseComponent } from "../entities/component";
 import { GlobalFunction, GlobalFunctions, GlobalMemberFunction, GlobalMemberFunctions, GlobalTag, GlobalTags } from "../entities/globals";
 import { Scope } from "../entities/scope";
@@ -411,7 +412,7 @@ async function cacheGivenComponents(componentUris: Uri[], _token: CancellationTo
                 if (token.isCancellationRequested) { break; }
 
                 try {
-                    const document: TextDocument = await workspace.openTextDocument(componentUri);
+                    const document: TextDocument = await LSTextDocument.openTextDocument(componentUri);
                     const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
                     const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
                     await cacheComponentFromDocument(document, false, replaceComments, _token);

--- a/src/utils/LSTextDocument.ts
+++ b/src/utils/LSTextDocument.ts
@@ -1,0 +1,121 @@
+import { EndOfLine, Position, Range, TextDocument, TextLine, Uri } from "vscode";
+import { TextDocument as FastTextDocument } from "vscode-languageserver-textdocument";
+const fs = require('fs').promises;
+
+export class LSTextDocument implements TextDocument {
+
+    // These are fixed as this implementation is not open for editing
+    readonly isUntitled: boolean = false;
+    readonly version: number = 1;
+    readonly isDirty: boolean = false;
+    readonly isClosed: boolean = false;
+
+    // These are set once in the constructor
+    public readonly uri: Uri;
+    public readonly fileName: string;
+    public readonly eol: EndOfLine;
+
+    // This is the actual text document
+    private textDocument: FastTextDocument;
+    private content: string;
+
+
+    // Pass these through to the actual text document
+    get languageId(): string {
+        return this.textDocument.languageId;
+    }
+    get lineCount(): number {
+        return this.textDocument.lineCount;
+    }
+
+    constructor(uri: Uri, languageId: string, version: number, content: string) {
+        this.textDocument = FastTextDocument.create(uri.toString(), languageId, version, content);
+        this.content = content;
+        this.uri = uri;
+        this.fileName = uri.fsPath;
+        this.eol = this.getEOL(content);
+        this.textDocument.uri
+        this.textDocument.version
+    }
+
+    public static async openTextDocument(uri: Uri, languageId: string = "plaintext"): Promise<LSTextDocument> {
+        const content = await fs.readFile(uri.fsPath, 'utf8');
+        const version = 1; // Initial version
+        return new LSTextDocument(uri, languageId, version, content);
+    }
+
+    private getEOL(text: string): EndOfLine {
+        const idx = text.indexOf('\n');
+        // Default to '\n' if the text has no lines at all
+        if (idx === -1) {
+            return EndOfLine.LF;
+        }
+        // Check the first '\n' character and see if it is preceded by '\r'
+        if (idx > 0 && text.charCodeAt(idx - 1) === 13) {
+            return EndOfLine.CRLF;
+        }
+        // Default to '\n'
+        return EndOfLine.LF;
+    }
+
+    save(): Thenable<boolean> {
+        throw new Error("Method not implemented.");
+    }
+
+    lineAt(line: number): TextLine;
+    lineAt(position: Position): TextLine;
+    lineAt(lineOrPosition: number | Position): TextLine {
+        if (typeof lineOrPosition === 'number') {
+            return this._lineAt(new Position(lineOrPosition, 0));
+        } else {
+            return this._lineAt(lineOrPosition);
+        }
+    }
+    _lineAt(position: Position): TextLine {
+        const lineText = this.textDocument.getText({
+            start: { line: position.line, character: 0 },
+            end: { line: position.line, character: Number.MAX_SAFE_INTEGER }
+        });
+        return {
+            lineNumber: position.line,
+            text: lineText,
+            range: new Range(new Position(position.line, 0), new Position(position.line, lineText.length)),
+            rangeIncludingLineBreak: new Range(new Position(position.line, 0), new Position(position.line + 1, 0)),
+            firstNonWhitespaceCharacterIndex: lineText.search(/\S|$/),
+            isEmptyOrWhitespace: lineText.trim().length === 0
+        };
+    }
+
+    offsetAt(position: Position): number {
+        return this.textDocument.offsetAt(position);
+    }
+    positionAt(offset: number): Position {
+        const pos = this.textDocument.positionAt(offset)
+        return new Position(pos.line, pos.character);
+    }
+    getText(range?: Range): string {
+        return this.textDocument.getText(range);
+    }
+
+    getWordRangeAtPosition(position: Position, regex?: RegExp): Range | undefined {
+        const text = this.content;
+        const offset = this.textDocument.offsetAt(position);
+        const start = text.lastIndexOf(' ', offset) + 1;
+        const end = text.indexOf(' ', offset);
+        if (start === -1 || end === -1) {
+            return undefined;
+        }
+        return new Range(this.positionAt(start), this.positionAt(end));
+    }
+    validateRange(range: Range): Range {
+        const start = this.positionAt(Math.max(0, this.offsetAt(range.start)));
+        const end = this.positionAt(Math.min(this.content.length, this.offsetAt(range.end)));
+        return new Range(start, end);
+    }
+    validatePosition(position: Position): Position {
+        const offset = this.offsetAt(position);
+        const validatedOffset = Math.max(0, Math.min(offset, this.content.length));
+        return this.positionAt(validatedOffset);
+    }
+
+}

--- a/src/utils/LSTextDocument.ts
+++ b/src/utils/LSTextDocument.ts
@@ -1,6 +1,5 @@
-import { EndOfLine, Position, Range, TextDocument, TextLine, Uri } from "vscode";
+import { EndOfLine, Position, Range, TextDocument, TextLine, Uri, workspace } from "vscode";
 import { TextDocument as FastTextDocument } from "vscode-languageserver-textdocument";
-const fs = require('fs').promises;
 
 export class LSTextDocument implements TextDocument {
 
@@ -39,7 +38,8 @@ export class LSTextDocument implements TextDocument {
     }
 
     public static async openTextDocument(uri: Uri, languageId: string = "plaintext"): Promise<LSTextDocument> {
-        const content = await fs.readFile(uri.fsPath, 'utf8');
+        const contentBytes = await workspace.fs.readFile(uri);
+        const content = new TextDecoder("utf-8").decode(contentBytes);
         const version = 1; // Initial version
         return new LSTextDocument(uri, languageId, version, content);
     }

--- a/src/utils/LSTextDocument.ts
+++ b/src/utils/LSTextDocument.ts
@@ -1,6 +1,21 @@
+// THIRD PARTY LICENSE NOTICE:
+//
+// Portions of this code are sourced from Visual Studio Code:
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+
 import { EndOfLine, Position, Range, TextDocument, TextLine, Uri, workspace } from "vscode";
 import { TextDocument as FastTextDocument } from "vscode-languageserver-textdocument";
+import { getWordAtText } from "./wordHelpers";
 
+/**
+ * LSTextDocument (Language Server Text Document)
+ *
+ * This is a replacement for `vscode.TextDocument` that uses `vscode-languageserver-textdocument.TextDocument` as the underlying implementation.
+ *
+ * This is intended to be faster than `vscode.TextDocument` as it doesn't interact with the editor.
+ */
 export class LSTextDocument implements TextDocument {
 
     // These are fixed as this implementation is not open for editing
@@ -16,8 +31,6 @@ export class LSTextDocument implements TextDocument {
 
     // This is the actual text document
     private textDocument: FastTextDocument;
-    private content: string;
-
 
     // Pass these through to the actual text document
     get languageId(): string {
@@ -28,11 +41,25 @@ export class LSTextDocument implements TextDocument {
     }
 
     constructor(uri: Uri, languageId: string, version: number, content: string) {
+        // Normalize line endings
+        // Note: This is done to match the behavior of vscode.TextDocument
+        let lineEnding = '\n';
+        const lineEndingMatch = content.match(/\r\n|\r|\n/g);
+        if (lineEndingMatch) {
+            lineEnding = lineEndingMatch[0];
+            // VS Code changes old Mac-style line endings to '\r\n'
+            if (lineEnding === '\r') {
+                lineEnding = '\r\n';
+            }
+            // Ensure the document has consistent line endings
+            content = content.replaceAll(/\r\n|\r|\n/g, lineEnding);
+        }
+
         this.textDocument = FastTextDocument.create(uri.toString(), languageId, version, content);
-        this.content = content;
+
         this.uri = uri;
         this.fileName = uri.fsPath;
-        this.eol = this.getEOL(content);
+        this.eol = lineEnding === '\r\n' ? EndOfLine.CRLF : EndOfLine.LF;
         this.textDocument.uri
         this.textDocument.version
     }
@@ -42,20 +69,6 @@ export class LSTextDocument implements TextDocument {
         const content = new TextDecoder("utf-8").decode(contentBytes);
         const version = 1; // Initial version
         return new LSTextDocument(uri, languageId, version, content);
-    }
-
-    private getEOL(text: string): EndOfLine {
-        const idx = text.indexOf('\n');
-        // Default to '\n' if the text has no lines at all
-        if (idx === -1) {
-            return EndOfLine.LF;
-        }
-        // Check the first '\n' character and see if it is preceded by '\r'
-        if (idx > 0 && text.charCodeAt(idx - 1) === 13) {
-            return EndOfLine.CRLF;
-        }
-        // Default to '\n'
-        return EndOfLine.LF;
     }
 
     save(): Thenable<boolean> {
@@ -97,25 +110,81 @@ export class LSTextDocument implements TextDocument {
         return this.textDocument.getText(range);
     }
 
+    // See: https://github.com/microsoft/deoptexplorer-vscode/blob/9a6bc239bf88a6c26a52a517d41e1a00e1d96353/src/third-party-derived/vscode/textDocumentLike.ts#L262
     getWordRangeAtPosition(position: Position, regex?: RegExp): Range | undefined {
-        const text = this.content;
-        const offset = this.textDocument.offsetAt(position);
-        const start = text.lastIndexOf(' ', offset) + 1;
-        const end = text.indexOf(' ', offset);
-        if (start === -1 || end === -1) {
-            return undefined;
+        position = this.validatePosition(position);
+
+        // Use the default regex, or validate a custom regex
+        if (!regex) {
+            regex = DEFAULT_WORD_REGEXP;
+        } else {
+            // Ensure a custom regex doesn't cause an infinite loop
+            regex.lastIndex = 0;
+            if (regex.test("") && regex.lastIndex === 0) {
+                throw new Error("Ignoring custom regexp because it matches the empty string.");
+            }
+            if (!regex.global || regex.sticky) {
+                let flags = "g";
+                if (regex.ignoreCase) flags += "i";
+                if (regex.multiline) flags += "m";
+                if (regex.unicode) flags += "u";
+                regex = new RegExp(regex.source, flags);
+            }
         }
-        return new Range(this.positionAt(start), this.positionAt(end));
+
+        /*
+            Scan the current line for a word that contains the position.
+             - If the regex is bad this could cause an infinite loop, which is why we validate it above.
+             - This can return null if it doesn't find a match in a set time.
+        */
+        const wordAtText = getWordAtText(
+            position.character + 1,
+            regex,
+            this.lineAt(position).text
+        );
+
+        if (wordAtText) {
+            return new Range(position.line, wordAtText.startColumn - 1, position.line, wordAtText.endColumn - 1);
+        }
+        return undefined;
     }
+
     validateRange(range: Range): Range {
-        const start = this.positionAt(Math.max(0, this.offsetAt(range.start)));
-        const end = this.positionAt(Math.min(this.content.length, this.offsetAt(range.end)));
+        // We need to recreate `vscode.TextDocument.validatePosition()`
+
+        // Validate the start and end positions separately
+        let start = this.positionAt(this.textDocument.offsetAt(range.start));
+        let end = this.positionAt(this.textDocument.offsetAt(range.end));
+
+        // Convert the validated positions back to a `vscode.Range`
         return new Range(start, end);
     }
+
     validatePosition(position: Position): Position {
-        const offset = this.offsetAt(position);
-        const validatedOffset = Math.max(0, Math.min(offset, this.content.length));
-        return this.positionAt(validatedOffset);
+        // We need to recreate `vscode.TextDocument.validatePosition()`
+
+        // We can leverage the validation in the `offsetAt` method
+        let validOffset = this.textDocument.offsetAt(position);
+
+        // Convert the offset back to a position and turn it into a `vscode.Position`
+        let pos = this.textDocument.positionAt(validOffset);
+        return new Position(pos.line, pos.character);
     }
 
 }
+
+/**
+This is the default word definition regex used by VSCode.
+
+`(-?\d*\.\d\w*)`
+- Floating point numbers
+- Matches `.1`, `-5.4f`, `123.0HelloWorld`
+
+`([^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)`
+- This ignores the printable ASCII characters except for "_"
+- Basically just `[a-zA-Z_]`
+- Matches `Hello_World`
+
+See: https://github.com/microsoft/vscode/blob/d718ff4ef98365abe53739bde33044a326a98f29/src/vs/editor/common/core/wordHelper.ts#L35C4-L35C92
+*/
+const DEFAULT_WORD_REGEXP = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g

--- a/src/utils/wordHelpers.ts
+++ b/src/utils/wordHelpers.ts
@@ -1,0 +1,82 @@
+// Source: https://github.com/microsoft/deoptexplorer-vscode/blob/9a6bc239bf88a6c26a52a517d41e1a00e1d96353/src/third-party-derived/vscode/wordHelpers.ts#L1
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// THIRD PARTY LICENSE NOTICE:
+//
+// Portions of this code are sourced from Visual Studio Code:
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+
+const maxLen = 1000;
+const timeBudget = 150;
+const windowSize = 15;
+
+export interface IWordAtPosition {
+    word: string;
+    /** 1-based column number */
+    startColumn: number;
+    /** 1-based column number */
+    endColumn: number;
+}
+
+// source: https://github.com/microsoft/vscode/blob/45aafeb326d0d3d56cbc9e2932f87e368dbf652d/src/vs/editor/common/model/wordHelper.ts#L64
+export function getWordAtText(column: number, wordDefinition: RegExp, text: string): IWordAtPosition | null {
+    let textOffset = 0;
+    if (text.length > maxLen) {
+        let start = column - maxLen / 2;
+        if (start < 0) {
+            start = 0;
+        }
+        else {
+            textOffset += start;
+        }
+        text = text.substring(start, column + maxLen / 2);
+    }
+    const t1 = Date.now();
+    const pos = column - 1 - textOffset;
+    let prevRegexIndex = -1;
+    let match: RegExpExecArray | null = null;
+    for (let i = 1; ; i++) {
+        if (Date.now() - t1 >= timeBudget) {
+            break;
+        }
+        const regexIndex = pos - windowSize * i;
+        wordDefinition.lastIndex = Math.max(0, regexIndex);
+        const thisMatch = _findRegexMatchEnclosingPosition(wordDefinition, text, pos, prevRegexIndex);
+        if (!thisMatch && match) {
+            break;
+        }
+        match = thisMatch;
+        if (regexIndex <= 0) {
+            break;
+        }
+        prevRegexIndex = regexIndex;
+    }
+    if (match) {
+        const result: IWordAtPosition = {
+            word: match[0],
+            startColumn: textOffset + 1 + match.index,
+            endColumn: textOffset + 1 + match.index + match[0].length
+        };
+        wordDefinition.lastIndex = 0;
+        return result;
+    }
+    return null;
+}
+
+function _findRegexMatchEnclosingPosition(wordDefinition: RegExp, text: string, pos: number, stopPos: number): RegExpExecArray | null {
+    let match: RegExpExecArray | null;
+    while (match = wordDefinition.exec(text)) {
+        if (match.index <= pos && wordDefinition.lastIndex >= pos) {
+            break;
+        }
+        else if (stopPos > 0 && match.index > stopPos) {
+            match = null;
+            break;
+        }
+    }
+    return match;
+}


### PR DESCRIPTION
This PR improves the performance of the `CFML: Refresh cache for workspace definitions` command that runs on startup. This is the "Caching components" progress meter that appears.

closes cfmleditor/cfmleditor#37

The only change to existing code is to swap `workspace.openTextDocument` with `LSTextDocument.openTextDocument`.

Performance measurements on a code base with 2000+ components:
- Before: 43.9 seconds (with various other extensions enabled)
- Before: 27.1 seconds (best case with all other extensions disabled)
- After: 15.9 seconds (same with or without other extensions)

The problem:

* `workspace.openTextDocument` is heavily tied into the VS Code editor and triggers all the normal events you would get from opening a file. This includes every extension that is listening for files to be opened.
* This is slow and causes a lot of garbage collection
* A listener on another extension can cause the caching step to take orders of magnitude longer. Think 5 minutes instead of 30 seconds.

The solution:

* VS Code has `vscode-languageserver-textdocument`, which is used for this kind of document parsing on language servers that can't access the editor context
* It would be great if we could just use this instead, but it doesn't implement all the methods for the `vscode.TextDocument` interface
* Rewriting the caching code to use `vscode-languageserver-textdocument` is impractical
* Add `LSTextDocument` (LS = Language Server) as a wrapper around `vscode-languageserver-textdocument` that implements the full `vscode.TextDocument` interface

Notes:

* Used https://github.com/microsoft/vscode and https://github.com/microsoft/deoptexplorer-vscode as references for tricky methods (both MIT licensed like CFML Editor)
* `src/utils/wordHelpers.ts` is copied entirely, with the only change being to add a notice at the top
* There are other places in the code that still use `workspace.openTextDocument`, but performance gains from changing them may not be as noticeable