### PR TITLE
Fix lint rule "require-await"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,7 +76,6 @@ export default [{
         "@typescript-eslint/no-unsafe-enum-comparison": "off",
         "@typescript-eslint/no-unsafe-member-access": "off",
         "@typescript-eslint/prefer-promise-reject-errors": "off",
-        "@typescript-eslint/require-await": "off",
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/restrict-template-expressions": "off",
         "@typescript-eslint/unbound-method": "off",

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -144,21 +144,14 @@ export function activate(context: ExtensionContext): object {
 
     context.subscriptions.push(commands.registerCommand("cfml.refreshGlobalDefinitionCache", refreshGlobalDefinitionCache));
     context.subscriptions.push(commands.registerCommand("cfml.refreshWorkspaceDefinitionCache", refreshWorkspaceDefinitionCache));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleLineComment", toggleComment(CommentType.Line, undefined)));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.insertSnippet", insertSnippet));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleBlockComment", toggleComment(CommentType.Block, undefined)));
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.openActiveApplicationFile", showApplicationDocument));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.goToMatchingTag", goToMatchingTag));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.openCfDocs", CFDocsService.openCfDocsForCurrentWord));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.openEngineDocs", CFDocsService.openEngineDocsForCurrentWord));
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     context.subscriptions.push(commands.registerTextEditorCommand("cfml.foldAllFunctions", foldAllFunctions));
 
     context.subscriptions.push(languages.registerHoverProvider(DOCUMENT_SELECTOR, new CFMLHoverProvider()));
@@ -189,7 +182,7 @@ export function activate(context: ExtensionContext): object {
             const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
             await cacheComponentFromDocument(document, false, replaceComments, undefined);
         } else if (resolveBaseName(document.fileName) === "Application.cfm") {
-            const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, false, true, undefined);
+            const documentStateContext: DocumentStateContext = getDocumentStateContext(document, false, true, undefined);
             const thisApplicationVariables: Variable[] = await parseVariableAssignments(documentStateContext, documentStateContext.docIsScript, undefined, undefined);
             const thisApplicationFilteredVariables: Variable[] = thisApplicationVariables.filter((variable: Variable) => {
                 return [Scope.Application, Scope.Session, Scope.Request].includes(variable.scope);
@@ -232,7 +225,7 @@ export function activate(context: ExtensionContext): object {
         }
 
         workspace.openTextDocument(applicationUri).then(async (document: TextDocument) => {
-            const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, false, true, undefined);
+            const documentStateContext: DocumentStateContext = getDocumentStateContext(document, false, true, undefined);
             const thisApplicationVariables: Variable[] = await parseVariableAssignments(documentStateContext, documentStateContext.docIsScript, undefined, undefined);
             const thisApplicationFilteredVariables: Variable[] = thisApplicationVariables.filter((variable: Variable) => {
                 return [Scope.Application, Scope.Session, Scope.Request].includes(variable.scope);

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -560,14 +560,14 @@ export function getServerUri(baseUri: Uri, _token: CancellationToken): Uri | und
  * @param _token
  * @returns
  */
-export async function isSubcomponentOrEqual(checkComponent: Component, baseComponent: Component, _token: CancellationToken): Promise<boolean> {
+export function isSubcomponentOrEqual(checkComponent: Component, baseComponent: Component, _token: CancellationToken): boolean {
     while (checkComponent) {
         if (checkComponent.uri.toString() === baseComponent.uri.toString()) {
             return true;
         }
 
         if (checkComponent.extends) {
-            checkComponent = await getComponent(checkComponent.extends, _token);
+            checkComponent = getComponent(checkComponent.extends, _token);
         } else {
             checkComponent = undefined;
         }
@@ -583,9 +583,9 @@ export async function isSubcomponentOrEqual(checkComponent: Component, baseCompo
  * @param _token
  * @returns
  */
-export async function isSubcomponent(checkComponent: Component, baseComponent: Component, _token: CancellationToken): Promise<boolean> {
+export function isSubcomponent(checkComponent: Component, baseComponent: Component, _token: CancellationToken): boolean {
     if (checkComponent.extends) {
-        checkComponent = await getComponent(checkComponent.extends, _token);
+        checkComponent = getComponent(checkComponent.extends, _token);
     } else {
         return false;
     }
@@ -596,7 +596,7 @@ export async function isSubcomponent(checkComponent: Component, baseComponent: C
         }
 
         if (checkComponent.extends) {
-            checkComponent = await getComponent(checkComponent.extends, _token);
+            checkComponent = getComponent(checkComponent.extends, _token);
         } else {
             checkComponent = undefined;
         }

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -880,7 +880,7 @@ export function getCfTags(documentStateContext: DocumentStateContext, isScript: 
  * @param edit
  * @param _token
  */
-export async function goToMatchingTag(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken = null): Promise<void> {
+export function goToMatchingTag(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken = null): void {
 
     const position: Position = editor.selection.active;
     const documentUri: Uri = editor.document.uri;
@@ -888,7 +888,7 @@ export async function goToMatchingTag(editor: TextEditor, edit: TextEditorEdit, 
     const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", documentUri);
     const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-    const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(editor.document, position, false, replaceComments, _token, false);
+    const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(editor.document, position, false, replaceComments, _token, false);
 
     const currentWord: string = documentPositionStateContext.currentWord;
     let globalTag: GlobalTag = getGlobalTag(currentWord);

--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -790,9 +790,9 @@ export async function getFunctionFromPrefix(documentPositionStateContext: Docume
         if (varMatchText.split(".").length === dotSeparatedCount) {
             if (documentPositionStateContext.isCfcFile && !varScope && equalsIgnoreCase(varName, "super")) {
                 if (documentPositionStateContext.component && documentPositionStateContext.component.extends, _token) {
-                    const baseComponent: Component = await getComponent(documentPositionStateContext.component.extends, _token);
+                    const baseComponent: Component = getComponent(documentPositionStateContext.component.extends, _token);
                     if (baseComponent) {
-                        foundFunction = await getFunctionFromComponent(baseComponent, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
+                        foundFunction = getFunctionFromComponent(baseComponent, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
                     }
                 }
             } else if (documentPositionStateContext.isCfcFile && !varScope && (equalsIgnoreCase(varName, Scope.Variables) || equalsIgnoreCase(varName, Scope.This))) {
@@ -803,7 +803,7 @@ export async function getFunctionFromPrefix(documentPositionStateContext: Docume
                 }
                 const disallowImplicit: boolean = equalsIgnoreCase(varName, Scope.Variables);
 
-                foundFunction = await getFunctionFromComponent(documentPositionStateContext.component, functionKey, documentPositionStateContext.document.uri, disallowedAccess, disallowImplicit, _token);
+                foundFunction = getFunctionFromComponent(documentPositionStateContext.component, functionKey, documentPositionStateContext.document.uri, disallowedAccess, disallowImplicit, _token);
             } else if (documentPositionStateContext.isCfmFile && !varScope && equalsIgnoreCase(varName, Scope.Variables)) {
                 foundFunction = await getFunctionFromTemplate(documentPositionStateContext, functionKey, _token);
             } else {
@@ -821,9 +821,9 @@ export async function getFunctionFromPrefix(documentPositionStateContext: Docume
                 const foundVar: Variable = getBestMatchingVariable(variableAssignments, varName, scopeVal);
 
                 if (foundVar && foundVar.dataTypeComponentUri) {
-                    const foundVarComponent: Component = await getComponent(foundVar.dataTypeComponentUri, _token);
+                    const foundVarComponent: Component = getComponent(foundVar.dataTypeComponentUri, _token);
                     if (foundVarComponent) {
-                        foundFunction = await getFunctionFromComponent(foundVarComponent, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
+                        foundFunction = getFunctionFromComponent(foundVarComponent, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
                     }
                 }
             }
@@ -831,7 +831,7 @@ export async function getFunctionFromPrefix(documentPositionStateContext: Docume
     } else if (documentPositionStateContext.isCfmFile) {
         foundFunction = await getFunctionFromTemplate(documentPositionStateContext, functionKey, _token);
     } else if (documentPositionStateContext.component) {
-        foundFunction = await getFunctionFromComponent(documentPositionStateContext.component, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
+        foundFunction = getFunctionFromComponent(documentPositionStateContext.component, functionKey, documentPositionStateContext.document.uri, undefined, false, _token);
     }
 
     return foundFunction;
@@ -847,11 +847,11 @@ export async function getFunctionFromPrefix(documentPositionStateContext: Docume
  * @param _token
  * @returns
  */
-export async function getFunctionFromComponent(component: Component, lowerFunctionName: string, callerUri: Uri, disallowedAccess: Access, disallowImplicit: boolean = false, _token: CancellationToken): Promise<UserFunction | undefined> {
+export function getFunctionFromComponent(component: Component, lowerFunctionName: string, callerUri: Uri, disallowedAccess: Access, disallowImplicit: boolean = false, _token: CancellationToken): UserFunction | undefined {
     const validFunctionAccess: MySet<Access> = new MySet([Access.Remote, Access.Public]);
     if (hasComponent(callerUri, _token)) {
-        const callerComponent: Component = await getComponent(callerUri, _token);
-        if (await isSubcomponentOrEqual(callerComponent, component, _token)) {
+        const callerComponent: Component = getComponent(callerUri, _token);
+        if (isSubcomponentOrEqual(callerComponent, component, _token)) {
             validFunctionAccess.add(Access.Private);
             validFunctionAccess.add(Access.Package);
         }
@@ -875,7 +875,7 @@ export async function getFunctionFromComponent(component: Component, lowerFuncti
         }
 
         if (currComponent.extends) {
-            currComponent = await getComponent(currComponent.extends, _token);
+            currComponent = getComponent(currComponent.extends, _token);
         } else {
             currComponent = undefined;
         }

--- a/src/entities/variable.ts
+++ b/src/entities/variable.ts
@@ -336,7 +336,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 
     // Add function arguments
     if (isCfcFile(document, _token)) {
-        const comp: Component = await getComponent(document.uri, _token);
+        const comp: Component = getComponent(document.uri, _token);
         if (comp) {
             comp.functions.forEach((func: UserFunction) => {
                 if (!func.isImplicit && (!docRange || (func.bodyRange && func.bodyRange.contains(docRange)))) {
@@ -914,7 +914,7 @@ export async function collectDocumentVariableAssignments(documentPositionStateCo
                 allVariableAssignments = allVariableAssignments.concat(componentVariables);
 
                 if (currComponent.extends) {
-                    currComponent = await getComponent(currComponent.extends, _token);
+                    currComponent = getComponent(currComponent.extends, _token);
                 } else {
                     currComponent = undefined;
                 }

--- a/src/features/cachedEntities.ts
+++ b/src/features/cachedEntities.ts
@@ -214,7 +214,7 @@ function setComponent(comp: Component): void {
  * @param _token
  * @returns
  */
-export async function getComponent(uri: Uri, _token: CancellationToken): Promise<Component> {
+export function getComponent(uri: Uri, _token: CancellationToken): Component {
     if (!hasComponent(uri, _token)) {
         /* TODO: If not already cached, attempt to read, parse and cache. Tricky since read is async */
         return undefined;
@@ -417,7 +417,7 @@ async function cacheGivenComponents(componentUris: Uri[], _token: CancellationTo
  * @returns
  */
 export async function cacheComponentFromDocument(document: TextDocument, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken): Promise<boolean> {
-    const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, fast, replaceComments, _token);
+    const documentStateContext: DocumentStateContext = getDocumentStateContext(document, fast, replaceComments, _token);
     try {
         const parsedComponent: Component | undefined = await parseComponent(documentStateContext, _token);
         if (!parsedComponent) {
@@ -497,7 +497,7 @@ async function cacheGivenApplicationCfms(applicationUris: Uri[], _token?: Cancel
             const document: TextDocument = await workspace.openTextDocument(applicationUri);
             const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
             const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
-            const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, false, replaceComments, _token);
+            const documentStateContext: DocumentStateContext = getDocumentStateContext(document, false, replaceComments, _token);
             const thisApplicationVariables: Variable[] = await parseVariableAssignments(documentStateContext, documentStateContext.docIsScript, undefined, _token);
             const thisApplicationFilteredVariables: Variable[] = thisApplicationVariables.filter((variable: Variable) => {
                 return [Scope.Application, Scope.Session, Scope.Request].includes(variable.scope);

--- a/src/features/colorProvider.ts
+++ b/src/features/colorProvider.ts
@@ -20,7 +20,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
      * @returns
      */
 
-    public async provideDocumentColors(document: TextDocument, _token: CancellationToken): Promise<ColorInformation[]> {
+    public provideDocumentColors(document: TextDocument, _token: CancellationToken): ColorInformation[] {
         // console.log("provideDocumentColors:CFMLDocumentColorProvider:" + _token?.isCancellationRequested);
 
         const result: ColorInformation[] = [];
@@ -28,7 +28,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
         // const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
         // const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-        const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, false, false, _token, true);
+        const documentStateContext: DocumentStateContext = getDocumentStateContext(document, false, false, _token, true);
         const cssRanges: Range[] = getCssRanges(documentStateContext, undefined, _token);
 
         for (const cssRange of cssRanges) {
@@ -142,7 +142,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
      * @returns
      */
 
-    public async provideColorPresentations(color: Color, context: { document: TextDocument, range: Range }, _token: CancellationToken): Promise<ColorPresentation[]> {
+    public provideColorPresentations(color: Color, context: { document: TextDocument, range: Range }, _token: CancellationToken): ColorPresentation[] {
         const result: ColorPresentation[] = [];
         const red256 = Math.round(color.red * 255), green256 = Math.round(color.green * 255), blue256 = Math.round(color.blue * 255);
 
@@ -156,7 +156,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 
         const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", context.document.uri);
         const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
-        const documentStateContext: DocumentStateContext = await getDocumentStateContext(context.document, false, replaceComments, _token);
+        const documentStateContext: DocumentStateContext = getDocumentStateContext(context.document, false, replaceComments, _token);
         const hexPrefix = isInCfOutput(documentStateContext, context.range.start, _token) ? "##" : "#";
         if (color.alpha === 1) {
             label = `${hexPrefix}${toTwoDigitHex(red256)}${toTwoDigitHex(green256)}${toTwoDigitHex(blue256)}`;

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -64,11 +64,11 @@ export async function showApplicationDocument(editor: TextEditor): Promise<void>
  * @param edit
  * @param _token
  */
-export async function foldAllFunctions(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): Promise<void> {
+export function foldAllFunctions(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): void {
     const document: TextDocument = editor.document;
 
     if (isCfcFile(document, _token)) {
-        const thisComponent: Component = await getComponent(document.uri, _token);
+        const thisComponent: Component = getComponent(document.uri, _token);
         if (thisComponent) {
             const functionStartLines: number[] = [];
             thisComponent.functions.filter((func: UserFunction) => {
@@ -91,10 +91,10 @@ export async function foldAllFunctions(editor: TextEditor, edit: TextEditorEdit,
  * @param args
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function insertSnippet(editor: TextEditor, edit: TextEditorEdit, args: any): Promise<void> {
+export function insertSnippet(editor: TextEditor, edit: TextEditorEdit, args: any): void {
 
     const position: Position = editor.selection.start;
-    const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(editor.document, position, false, true, null, false);
+    const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(editor.document, position, false, true, null, false);
 
     if (documentPositionStateContext.positionIsScript) {
         commands.executeCommand("editor.action.insertSnippet", {

--- a/src/features/comment.ts
+++ b/src/features/comment.ts
@@ -35,8 +35,8 @@ export const cfmlCommentRules: CFMLCommentRules = {
  * @param _token
  * @returns
  */
-async function isTagComment(document: TextDocument, startPosition: Position, _token: CancellationToken): Promise<boolean> {
-    const docIsScript: boolean = (isCfcFile(document, _token) && hasComponent(document.uri, _token) && (await getComponent(document.uri, _token)).isScript);
+function isTagComment(document: TextDocument, startPosition: Position, _token: CancellationToken): boolean {
+    const docIsScript: boolean = (isCfcFile(document, _token) && hasComponent(document.uri, _token) && (getComponent(document.uri, _token)).isScript);
 
     return !docIsScript && !isInCfScript(document, startPosition, _token);
 }
@@ -63,8 +63,8 @@ function getCommentCommand(commentType: CommentType): string {
  * @param _token
  * @returns
  */
-export function toggleComment(commentType: CommentType, _token: CancellationToken): (editor: TextEditor) => Promise<void> {
-    return async (editor: TextEditor) => {
+export function toggleComment(commentType: CommentType, _token: CancellationToken): (editor: TextEditor) => void {
+    return (editor: TextEditor) => {
         if (editor) {
             // default comment config
             let languageConfig: LanguageConfiguration = {
@@ -82,7 +82,7 @@ export function toggleComment(commentType: CommentType, _token: CancellationToke
             };
 
             // Changes the comment in language configuration based on the context
-            if (await isTagComment(editor.document, editor.selection.start, _token)) {
+            if (isTagComment(editor.document, editor.selection.start, _token)) {
                 languageConfig = {
                     comments: {
                         blockComment: cfmlCommentRules.tagBlockComment

--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -115,7 +115,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
 
         const cfscriptRanges: Range[] = getCfScriptRanges(document, undefined, _token);
 
-        const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+        const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
 
         const currentWordMatches = (name: string): boolean => {
             return matches(documentPositionStateContext.currentWord, name);
@@ -359,7 +359,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
                 });
             }
         } else if (docIsCfcFile) {
-            const componentFunctionCompletions: CompletionItem[] = await getComponentFunctionCompletions(completionState, thisComponent, _token);
+            const componentFunctionCompletions: CompletionItem[] = getComponentFunctionCompletions(completionState, thisComponent, _token);
             result = result.concat(componentFunctionCompletions);
         }
 
@@ -384,7 +384,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
                 // From super keyword
                 if (docIsCfcFile && !varScope && equalsIgnoreCase(varName, "super")) {
                     const addedFunctions: MySet<string> = new MySet();
-                    const baseComponent: Component = await getComponent(thisComponent.extends, _token);
+                    const baseComponent: Component = getComponent(thisComponent.extends, _token);
                     let currComponent: Component = baseComponent;
                     while (currComponent) {
                         currComponent.functions.filter((_func: UserFunction, funcKey: string) => {
@@ -397,7 +397,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
                         });
 
                         if (currComponent.extends) {
-                            currComponent = await getComponent(currComponent.extends, _token);
+                            currComponent = getComponent(currComponent.extends, _token);
                         } else {
                             currComponent = undefined;
                         }
@@ -410,14 +410,14 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
                     if (foundVar) {
                         // From component variable
                         if (foundVar.dataTypeComponentUri) {
-                            const initialFoundComp: Component = await getComponent(foundVar.dataTypeComponentUri, _token);
+                            const initialFoundComp: Component = getComponent(foundVar.dataTypeComponentUri, _token);
 
                             if (initialFoundComp) {
                                 const addedFunctions: MySet<string> = new MySet();
                                 const addedVariables: MySet<string> = new MySet();
                                 const validFunctionAccess: MySet<Access> = new MySet([Access.Remote, Access.Public]);
                                 if (thisComponent) {
-                                    if (await isSubcomponentOrEqual(thisComponent, initialFoundComp, _token)) {
+                                    if (isSubcomponentOrEqual(thisComponent, initialFoundComp, _token)) {
                                         validFunctionAccess.add(Access.Private);
                                         validFunctionAccess.add(Access.Package);
                                     }
@@ -458,7 +458,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
                                     });
 
                                     if (foundComponent.extends) {
-                                        foundComponent = await getComponent(foundComponent.extends, _token);
+                                        foundComponent = getComponent(foundComponent.extends, _token);
                                     } else {
                                         foundComponent = undefined;
                                     }
@@ -627,7 +627,7 @@ export default class CFMLCompletionItemProvider implements CompletionItemProvide
  * @param attributesLength The length of the entity's attributes string
  * @returns
  */
-async function getGlobalTagAttributeCompletions(state: CompletionState, globalTag: GlobalTag, attributeStartOffset: number, attributesLength: number): Promise<CompletionItem[]> {
+function getGlobalTagAttributeCompletions(state: CompletionState, globalTag: GlobalTag, attributeStartOffset: number, attributesLength: number): CompletionItem[] {
     const attributeDocs: MyMap<string, Parameter> = new MyMap<string, Parameter>();
     globalTag.signatures.forEach((sig: Signature) => {
         sig.parameters.forEach((param: Parameter) => {
@@ -638,7 +638,7 @@ async function getGlobalTagAttributeCompletions(state: CompletionState, globalTa
     const tagAttributeRange = new Range(state.document.positionAt(attributeStartOffset), state.document.positionAt(attributeStartOffset + attributesLength));
     const parsedAttributes: Attributes = parseAttributes(state.document, tagAttributeRange, attributeNames);
     const usedAttributeNames: MySet<string> = new MySet(parsedAttributes.keys());
-    const attributeCompletions: CompletionItem[] = await getCFTagAttributeCompletions(state, globalTag, Array.from(attributeDocs.values()), usedAttributeNames);
+    const attributeCompletions: CompletionItem[] = getCFTagAttributeCompletions(state, globalTag, Array.from(attributeDocs.values()), usedAttributeNames);
 
     return attributeCompletions;
 }
@@ -651,7 +651,7 @@ async function getGlobalTagAttributeCompletions(state: CompletionState, globalTa
  * @param usedAttributeNames The set of attribute names that are already being used
  * @returns
  */
-async function getCFTagAttributeCompletions(state: CompletionState, globalTag: GlobalTag, params: Parameter[], usedAttributeNames: MySet<string>): Promise<CompletionItem[]> {
+function getCFTagAttributeCompletions(state: CompletionState, globalTag: GlobalTag, params: Parameter[], usedAttributeNames: MySet<string>): CompletionItem[] {
     const cfmlGTAttributesQuoteType: AttributeQuoteType = state.cfmlCompletionSettings.get<AttributeQuoteType>("globalTags.attributes.quoteType", AttributeQuoteType.Double);
     const cfmlGTAttributesDefault: boolean = state.cfmlCompletionSettings.get<boolean>("globalTags.attributes.defaultValue", false);
 
@@ -864,7 +864,7 @@ function getVariableCompletions(state: CompletionState, variables: Variable[]): 
  * @param _token
  * @returns
  */
-async function getComponentFunctionCompletions(state: CompletionState, component: Component, _token: CancellationToken): Promise<CompletionItem[]> {
+function getComponentFunctionCompletions(state: CompletionState, component: Component, _token: CancellationToken): CompletionItem[] {
     const componentFunctionCompletions: CompletionItem[] = [];
     if (component) {
         const addedFunctions: MySet<string> = new MySet();
@@ -891,7 +891,7 @@ async function getComponentFunctionCompletions(state: CompletionState, component
             });
 
             if (currComponent.extends) {
-                currComponent = await getComponent(currComponent.extends, _token);
+                currComponent = getComponent(currComponent.extends, _token);
             } else {
                 currComponent = undefined;
             }

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -31,7 +31,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
         const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
         const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-        const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+        const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
 
         if (documentPositionStateContext.positionInComment) {
             return null;
@@ -54,7 +54,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
 
         // TODO: These references should ideally be in cachedEntities.
         let referenceMatch: RegExpExecArray | null;
-        await Promise.all(objectReferencePatterns.map(async (element: ReferencePattern) => {
+        await Promise.all(objectReferencePatterns.map((element: ReferencePattern) => {
             const pattern: RegExp = element.pattern;
             while ((referenceMatch = pattern.exec(documentText))) {
                 const path: string = referenceMatch[element.refIndex];
@@ -67,7 +67,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                 if (pathRange.contains(position)) {
                     const componentUri: Uri = cachedComponentPathToUri(path, document.uri, _token);
                     if (componentUri) {
-                        const comp: Component = await getComponent(componentUri, _token);
+                        const comp: Component = getComponent(componentUri, _token);
                         if (comp) {
                             results.push({
                                 originSelectionRange: pathRange,
@@ -86,7 +86,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
             if (thisComponent) {
                 // Extends
                 if (thisComponent.extendsRange && thisComponent.extendsRange.contains(position)) {
-                    const extendsComp: Component = await getComponent(thisComponent.extends, _token);
+                    const extendsComp: Component = getComponent(thisComponent.extends, _token);
                     if (extendsComp) {
                         results.push({
                             originSelectionRange: thisComponent.extendsRange,
@@ -99,9 +99,9 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
 
                 // Implements
                 if (thisComponent.implementsRanges) {
-                    await Promise.all(thisComponent.implementsRanges.map(async (range: Range, idx: number) => {
+                    await Promise.all(thisComponent.implementsRanges.map((range: Range, idx: number) => {
                         if (range && range.contains(position)) {
-                            const implComp: Component = await getComponent(thisComponent.implements[idx], _token);
+                            const implComp: Component = getComponent(thisComponent.implements[idx], _token);
                             if (implComp) {
                                 results.push({
                                     originSelectionRange: range,
@@ -118,7 +118,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                 for (const [, func] of thisComponent.functions) {
                     // Function return types
                     if (func.returnTypeUri && func.returnTypeRange && func.returnTypeRange.contains(position)) {
-                        const returnTypeComp: Component = await getComponent(func.returnTypeUri, _token);
+                        const returnTypeComp: Component = getComponent(func.returnTypeUri, _token);
                         if (returnTypeComp) {
                             results.push({
                                 originSelectionRange: func.returnTypeRange,
@@ -135,8 +135,8 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                             return arg.dataTypeComponentUri && arg.dataTypeRange && arg.dataTypeRange.contains(position);
                         });
 
-                        await Promise.all(parameters.map(async (arg: Argument) => {
-                            const argTypeComp: Component = await getComponent(arg.dataTypeComponentUri, _token);
+                        await Promise.all(parameters.map((arg: Argument) => {
+                            const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                             if (argTypeComp) {
                                 results.push({
                                     originSelectionRange: arg.dataTypeRange,
@@ -190,7 +190,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                 })
 
                 for (const [, prop] of componentproperties) {
-                    const dataTypeComp: Component = await getComponent(prop.dataTypeComponentUri, _token);
+                    const dataTypeComp: Component = getComponent(prop.dataTypeComponentUri, _token);
                     if (dataTypeComp) {
                         results.push({
                             originSelectionRange: prop.dataTypeRange,

--- a/src/features/docBlocker/block.ts
+++ b/src/features/docBlocker/block.ts
@@ -49,8 +49,8 @@ export abstract class Block {
 
   }
 
-  public async setup(): Promise<void> {
-    this.component = await getComponent(this.document.uri, undefined);
+  public setup(): void {
+    this.component = getComponent(this.document.uri, undefined);
   }
 
   /**

--- a/src/features/docBlocker/docCompletionProvider.ts
+++ b/src/features/docBlocker/docCompletionProvider.ts
@@ -25,7 +25,7 @@ export default class DocBlockCompletions implements CompletionItemProvider {
      * @returns
      */
 
-    public async provideCompletionItems(document: TextDocument, position: Position, _token: CancellationToken): Promise<CompletionItem[]> {
+    public provideCompletionItems(document: TextDocument, position: Position, _token: CancellationToken): CompletionItem[] {
 
         // console.log("provideCompletionItems:DocBlockCompletions:" + _token?.isCancellationRequested);
 
@@ -37,14 +37,14 @@ export default class DocBlockCompletions implements CompletionItemProvider {
 
             const block = new CompletionItem("/** */", CompletionItemKind.Snippet);
             block.range = wordMatchRange;
-            block.insertText = await documenter.autoDocument();
+            block.insertText = documenter.autoDocument();
             block.documentation = "Docblock completion";
             result.push(block);
 
             return result;
         }
 
-        const comp: Component = await getComponent(document.uri, _token);
+        const comp: Component = getComponent(document.uri, _token);
         if (!comp) {
             return result;
         }

--- a/src/features/docBlocker/documenter.ts
+++ b/src/features/docBlocker/documenter.ts
@@ -34,21 +34,21 @@ export default class Documenter {
      * if not load an empty block
      * @returns
      */
-    public async autoDocument(): Promise<SnippetString> {
+    public autoDocument(): SnippetString {
         const func = new FunctionBlock(this.targetPosition, this.document);
-        await func.setup();
+        func.setup();
         if (func.test()) {
             return func.constructDoc().build();
         }
 
         const prop = new Property(this.targetPosition, this.document);
-        await prop.setup();
+        prop.setup();
         if (prop.test()) {
             return prop.constructDoc().build();
         }
 
         const comp = new Component(this.targetPosition, this.document);
-        await comp.setup();
+        comp.setup();
         if (comp.test()) {
             return comp.constructDoc().build();
         }

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -28,7 +28,7 @@ export default class CFMLDocumentSymbolProvider implements DocumentSymbolProvide
         const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
         const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-        const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, false, replaceComments, _token, true);
+        const documentStateContext: DocumentStateContext = getDocumentStateContext(document, false, replaceComments, _token, true);
 
         if (documentStateContext.isCfcFile) {
             const componentSymbols = await CFMLDocumentSymbolProvider.getComponentSymbols(documentStateContext, _token)
@@ -49,7 +49,7 @@ export default class CFMLDocumentSymbolProvider implements DocumentSymbolProvide
      */
     private static async getComponentSymbols(documentStateContext: DocumentStateContext, _token: CancellationToken): Promise<DocumentSymbol[]> {
         const document: TextDocument = documentStateContext.document;
-        const component: Component = await getComponent(document.uri, _token);
+        const component: Component = getComponent(document.uri, _token);
 
         if (!component) {
             return [];

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -84,7 +84,7 @@ export default class CFMLHoverProvider implements HoverProvider {
         let definition: HoverProviderItem;
         const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
         const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
-        const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, true);
+        const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, true);
         const userEngine: CFMLEngine = documentPositionStateContext.userEngine;
         const textLine: TextLine = document.lineAt(position);
         const lineText: string = documentPositionStateContext.sanitizedDocumentText.slice(document.offsetAt(textLine.range.start), document.offsetAt(textLine.range.end));
@@ -125,7 +125,7 @@ export default class CFMLHoverProvider implements HoverProvider {
         if (objectNewInstanceInitPrefixMatch && objectNewInstanceInitPrefixMatch[2] === componentPathWord) {
             const componentUri: Uri = cachedComponentPathToUri(componentPathWord, document.uri, _token);
             if (componentUri) {
-                const initComponent: Component = await getComponent(componentUri, _token);
+                const initComponent: Component = getComponent(componentUri, _token);
                 if (initComponent) {
                     const initMethod = initComponent.initmethod ? initComponent.initmethod.toLowerCase() : "init";
                     if (initComponent.functions.has(initMethod)) {

--- a/src/features/signatureHelpProvider.ts
+++ b/src/features/signatureHelpProvider.ts
@@ -34,7 +34,7 @@ export default class CFMLSignatureHelpProvider implements SignatureHelpProvider 
     const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
     const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-    const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+    const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
     if (documentPositionStateContext.positionInComment) {
       return null;
     }
@@ -72,7 +72,7 @@ export default class CFMLSignatureHelpProvider implements SignatureHelpProvider 
       const componentDotPath: string = objectNewInstanceInitPrefixMatch[2];
       const componentUri: Uri = cachedComponentPathToUri(componentDotPath, document.uri, _token);
       if (componentUri) {
-        const initComponent: Component = await getComponent(componentUri, _token);
+        const initComponent: Component = getComponent(componentUri, _token);
         if (initComponent) {
           const initMethod: string = initComponent.initmethod ? initComponent.initmethod.toLowerCase() : "init";
           if (initComponent.functions.has(initMethod)) {

--- a/src/features/typeDefinitionProvider.ts
+++ b/src/features/typeDefinitionProvider.ts
@@ -26,7 +26,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
         const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
         const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-        const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+        const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
 
         if (documentPositionStateContext.positionInComment) {
             return null;
@@ -54,8 +54,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                             return arg.dataTypeComponentUri && arg.nameRange && arg.nameRange.contains(position);
                         })
 
-                        await Promise.all(signatureparameters.map(async (arg: Argument) => {
-                            const argTypeComp: Component = await getComponent(arg.dataTypeComponentUri, _token);
+                        await Promise.all(signatureparameters.map((arg: Argument) => {
+                            const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                             if (argTypeComp) {
                                 results.push(new Location(
                                     argTypeComp.uri,
@@ -73,8 +73,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                             const localVariablesfiltered = localVariables.filter((localVar: Variable) => {
                                 return position.isAfterOrEqual(localVar.declarationLocation.range.start) && equalsIgnoreCase(localVar.identifier, currentWord) && localVar.dataTypeComponentUri;
                             });
-                            await Promise.all(localVariablesfiltered.map(async (localVar: Variable) => {
-                                const localVarTypeComp: Component = await getComponent(localVar.dataTypeComponentUri, _token);
+                            await Promise.all(localVariablesfiltered.map((localVar: Variable) => {
+                                const localVarTypeComp: Component = getComponent(localVar.dataTypeComponentUri, _token);
                                 if (localVarTypeComp) {
                                     results.push(new Location(
                                         localVarTypeComp.uri,
@@ -92,8 +92,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                                     const signatureparameters = signature.parameters.filter((arg: Argument) => {
                                         return equalsIgnoreCase(arg.name, currentWord) && arg.dataTypeComponentUri;
                                     });
-                                    await Promise.all(signatureparameters.map(async (arg: Argument) => {
-                                        const argTypeComp: Component = await getComponent(arg.dataTypeComponentUri, _token);
+                                    await Promise.all(signatureparameters.map((arg: Argument) => {
+                                        const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                                         if (argTypeComp) {
                                             results.push(new Location(
                                                 argTypeComp.uri,
@@ -113,7 +113,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 })
 
                 for (const [, prop] of thisComponentproperties) {
-                    const propTypeComp: Component = await getComponent(prop.dataTypeComponentUri, _token);
+                    const propTypeComp: Component = getComponent(prop.dataTypeComponentUri, _token);
                     if (propTypeComp) {
                         results.push(new Location(
                             propTypeComp.uri,
@@ -129,8 +129,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                     const thisComponentvariables = thisComponent.variables.filter((variable: Variable) => {
                         return equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
                     });
-                    await Promise.all(thisComponentvariables.map(async (variable: Variable) => {
-                        const varTypeComp: Component = await getComponent(variable.dataTypeComponentUri, _token);
+                    await Promise.all(thisComponentvariables.map((variable: Variable) => {
+                        const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                         if (varTypeComp) {
                             results.push(new Location(
                                 varTypeComp.uri,
@@ -163,8 +163,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                     return (unscopedPrecedence.includes(variable.scope) || variable.scope === Scope.Unknown);
                 });
 
-                await Promise.all(docVariableAssignmentsfiltered.map(async (variable: Variable) => {
-                    const varTypeComp: Component = await getComponent(variable.dataTypeComponentUri, _token);
+                await Promise.all(docVariableAssignmentsfiltered.map((variable: Variable) => {
+                    const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                     if (varTypeComp) {
                         results.push(new Location(
                             varTypeComp.uri,
@@ -178,7 +178,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
         // User functions
         const externalUserFunc: UserFunction = await getFunctionFromPrefix(documentPositionStateContext, lowerCurrentWord, undefined, _token);
         if (externalUserFunc && externalUserFunc.returnTypeUri) {
-            const returnTypeComponent: Component = await getComponent(externalUserFunc.returnTypeUri, _token);
+            const returnTypeComponent: Component = getComponent(externalUserFunc.returnTypeUri, _token);
             if (returnTypeComponent) {
                 results.push(new Location(
                     returnTypeComponent.uri,
@@ -198,8 +198,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 return variable.scope === currentScope && equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
             });
 
-            await Promise.all(applicationDocVariablesfiltered.map(async (variable: Variable) => {
-                const varTypeComp: Component = await getComponent(variable.dataTypeComponentUri, _token);
+            await Promise.all(applicationDocVariablesfiltered.map((variable: Variable) => {
+                const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                 if (varTypeComp) {
                     results.push(new Location(
                         varTypeComp.uri,
@@ -217,8 +217,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 return variable.scope === Scope.Server && equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
             });
 
-            await Promise.all(serverDocVariablesfiltered.map(async (variable: Variable) => {
-                const varTypeComp: Component = await getComponent(variable.dataTypeComponentUri, _token);
+            await Promise.all(serverDocVariablesfiltered.map((variable: Variable) => {
+                const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                 if (varTypeComp) {
                     results.push(new Location(
                         varTypeComp.uri,

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -16,7 +16,7 @@ export default class CFMLWorkspaceSymbolProvider implements WorkspaceSymbolProvi
      * @returns
      */
 
-    public async provideWorkspaceSymbols(query: string, _token: CancellationToken): Promise<SymbolInformation[]> {
+    public provideWorkspaceSymbols(query: string, _token: CancellationToken): SymbolInformation[] {
 
         // console.log("provideWorkspaceSymbols:CFMLWorkspaceSymbolProvider:" + _token?.isCancellationRequested);
 

--- a/src/utils/cfdocs/cfDocsService.ts
+++ b/src/utils/cfdocs/cfDocsService.ts
@@ -326,14 +326,14 @@ export default class CFDocsService {
    * @param editor
    * @editor The text editor which represents the document for which to check the word
    */
-  public static async openCfDocsForCurrentWord(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): Promise<void> {
+  public static openCfDocsForCurrentWord(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): void {
     const document: TextDocument = editor.document;
     const position: Position = editor.selection.start;
 
     const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
     const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-    const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+    const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
 
     if (documentPositionStateContext.positionInComment) {
       return;
@@ -368,14 +368,14 @@ export default class CFDocsService {
    * Opens the documentation web page of the currently set CF engine for the word at the current cursor position
    * @editor The text editor which represents the document for which to check the word
    */
-  public static async openEngineDocsForCurrentWord(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): Promise<void> {
+  public static openEngineDocsForCurrentWord(editor: TextEditor, edit: TextEditorEdit, _token: CancellationToken): void {
     const document: TextDocument = editor.document;
     const position: Position = editor.selection.start;
 
     const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest", document.uri);
     const replaceComments = cfmlCompletionSettings.get<boolean>("replaceComments", true);
 
-    const documentPositionStateContext: DocumentPositionStateContext = await getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
+    const documentPositionStateContext: DocumentPositionStateContext = getDocumentPositionStateContext(document, position, false, replaceComments, _token, false);
 
     if (documentPositionStateContext.positionInComment) {
       return;

--- a/src/utils/documentUtil.ts
+++ b/src/utils/documentUtil.ts
@@ -38,7 +38,7 @@ export interface DocumentPositionStateContext extends DocumentStateContext {
  * @param exclDocumentRanges
  * @returns DocumentStateContext
  */
-export async function getDocumentStateContext(document: TextDocument, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken, exclDocumentRanges: boolean = false): Promise<DocumentStateContext> {
+export function getDocumentStateContext(document: TextDocument, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken, exclDocumentRanges: boolean = false): DocumentStateContext {
     const cfmlEngineSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.engine");
     const userEngineName: CFMLEngineName = CFMLEngineName.valueOf(cfmlEngineSettings.get<string>("name"));
     const userEngine: CFMLEngine = new CFMLEngine(userEngineName, cfmlEngineSettings.get<string>("version"));
@@ -46,14 +46,14 @@ export async function getDocumentStateContext(document: TextDocument, fast: bool
     const docIsCfcFile: boolean = isCfcFile(document, _token);
     const docIsCfmFile: boolean = isCfmFile(document, _token);
     const docIsCfsFile: boolean = isCfsFile(document, _token);
-    const thisComponent: Component = await getComponent(document.uri, _token);
+    const thisComponent: Component = getComponent(document.uri, _token);
     const docIsScript: boolean = (docIsCfcFile && isScriptComponent(document, _token)) || docIsCfsFile;
 
     const documentRanges: DocumentContextRanges = getDocumentContextRanges(document, docIsScript, undefined, fast, _token, exclDocumentRanges);
     const commentRanges: Range[] = documentRanges.commentRanges;
     const stringRanges: Range[] = documentRanges.stringRanges;
     const stringEmbeddedCfmlRanges: Range[] = documentRanges.stringEmbeddedCfmlRanges;
-    const sanitizedDocumentText: string = await getSanitizedDocumentText(document, commentRanges, replaceComments, _token);
+    const sanitizedDocumentText: string = getSanitizedDocumentText(document, commentRanges, replaceComments, _token);
 
     return {
         document,
@@ -79,8 +79,8 @@ export async function getDocumentStateContext(document: TextDocument, fast: bool
  * @param exclDocumentRanges
  * @returns DocumentPositionStateContext
  */
-export async function getDocumentPositionStateContext(document: TextDocument, position: Position, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken, exclDocumentRanges: boolean = false): Promise<DocumentPositionStateContext> {
-    const documentStateContext: DocumentStateContext = await getDocumentStateContext(document, fast, replaceComments, _token, exclDocumentRanges);
+export function getDocumentPositionStateContext(document: TextDocument, position: Position, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken, exclDocumentRanges: boolean = false): DocumentPositionStateContext {
+    const documentStateContext: DocumentStateContext = getDocumentStateContext(document, fast, replaceComments, _token, exclDocumentRanges);
 
     const docIsScript: boolean = documentStateContext.docIsScript;
     const positionInComment: boolean = isInRanges(documentStateContext.commentRanges, position, false, _token);

--- a/src/utils/textUtil.ts
+++ b/src/utils/textUtil.ts
@@ -99,7 +99,7 @@ export function replaceRangeWithSpaces(document: TextDocument, ranges: Range[]):
  * @param _token
  * @returns string
  */
-export async function getSanitizedDocumentText(document: TextDocument, commentRanges: Range[], replaceComments: boolean = false, _token: CancellationToken): Promise<string> {
+export function getSanitizedDocumentText(document: TextDocument, commentRanges: Range[], replaceComments: boolean = false, _token: CancellationToken): string {
     if (replaceComments !== true) {
         return document.getText();
     }
@@ -107,7 +107,7 @@ export async function getSanitizedDocumentText(document: TextDocument, commentRa
     if (commentRanges) {
         documentCommentRanges = commentRanges;
     } else {
-        const docIsScript: boolean = (isCfcFile(document, _token) && hasComponent(document.uri, _token) && (await getComponent(document.uri, _token)).isScript);
+        const docIsScript: boolean = (isCfcFile(document, _token) && hasComponent(document.uri, _token) && (getComponent(document.uri, _token)).isScript);
         documentCommentRanges = getDocumentContextRanges(document, docIsScript, undefined, false, _token).commentRanges;
     }
 
@@ -122,10 +122,10 @@ export async function getSanitizedDocumentText(document: TextDocument, commentRa
  * @param _token
  * @returns string
  */
-export async function getPrefixText(document: TextDocument, position: Position, replaceComments: boolean = false, _token: CancellationToken): Promise<string> {
+export function getPrefixText(document: TextDocument, position: Position, replaceComments: boolean = false, _token: CancellationToken): string {
     let documentText: string = document.getText();
     if (replaceComments) {
-        documentText = await getSanitizedDocumentText(document, undefined, false, _token);
+        documentText = getSanitizedDocumentText(document, undefined, false, _token);
     }
 
     return documentText.slice(0, document.offsetAt(position));


### PR DESCRIPTION
Removed async from getComponent. This function retrieves a component from the cache, and should never need to wait on anything. This allows removing async from a lot of other functions as well.