### PR TITLE
Fix broken definitions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "DavidAnson.vscode-markdownlint",
-        "eg2.vscode-npm-script",
         "dbaeumer.vscode-eslint",
         "amodio.tsl-problem-matcher"
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,10 +30,7 @@
     {
       "type": "npm",
       "script": "lint",
-      "problemMatcher": {
-        "base": "$tslint5",
-        "fileLocation": "relative"
-      }
+      "problemMatcher": "$eslint-stylish",
     },
     {
         "type": "npm",

--- a/src/entities/dataType.ts
+++ b/src/entities/dataType.ts
@@ -202,7 +202,7 @@ export namespace DataType {
    */
   export async function getDataTypeAndUri(dataType: string, documentUri: Uri, _token: CancellationToken): Promise<[DataType, Uri]> {
     if (!dataType) {
-      return undefined;
+      return [null, null];
     }
 
     if (isDataType(dataType)) {
@@ -214,7 +214,7 @@ export namespace DataType {
       }
     }
 
-    return undefined;
+    return [null, null];
   }
 
   /**

--- a/src/features/cachedEntities.ts
+++ b/src/features/cachedEntities.ts
@@ -416,19 +416,13 @@ async function cacheGivenComponents(componentUris: Uri[], _token: CancellationTo
  * @param _token
  * @returns
  */
-export async function cacheComponentFromDocument(document: TextDocument, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken): Promise<boolean> {
+export async function cacheComponentFromDocument(document: TextDocument, fast: boolean = false, replaceComments: boolean = false, _token: CancellationToken): Promise<void> {
     const documentStateContext: DocumentStateContext = getDocumentStateContext(document, fast, replaceComments, _token);
-    try {
-        const parsedComponent: Component | undefined = await parseComponent(documentStateContext, _token);
-        if (!parsedComponent) {
-            return false;
-        }
-        await cacheComponent(parsedComponent, documentStateContext, _token);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (err) {
-        return false;
+    const parsedComponent: Component | undefined = await parseComponent(documentStateContext, _token);
+    if (!parsedComponent) {
+        return;
     }
-    return true;
+    await cacheComponent(parsedComponent, documentStateContext, _token);
 }
 
 /**

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -54,7 +54,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
 
         // TODO: These references should ideally be in cachedEntities.
         let referenceMatch: RegExpExecArray | null;
-        await Promise.all(objectReferencePatterns.map((element: ReferencePattern) => {
+        objectReferencePatterns.map((element: ReferencePattern) => {
             const pattern: RegExp = element.pattern;
             while ((referenceMatch = pattern.exec(documentText))) {
                 const path: string = referenceMatch[element.refIndex];
@@ -79,7 +79,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                     }
                 }
             }
-        }));
+        });
 
         if (docIsCfcFile) {
             const thisComponent: Component = documentPositionStateContext.component;
@@ -99,7 +99,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
 
                 // Implements
                 if (thisComponent.implementsRanges) {
-                    await Promise.all(thisComponent.implementsRanges.map((range: Range, idx: number) => {
+                    thisComponent.implementsRanges.map((range: Range, idx: number) => {
                         if (range && range.contains(position)) {
                             const implComp: Component = getComponent(thisComponent.implements[idx], _token);
                             if (implComp) {
@@ -111,7 +111,7 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                                 });
                             }
                         }
-                    }));
+                    });
                 }
 
                 // Component functions (related)
@@ -130,12 +130,12 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                     }
 
                     // Argument types
-                    await Promise.all(func.signatures.map(async (signature: UserFunctionSignature) => {
+                    func.signatures.map((signature: UserFunctionSignature) => {
                         const parameters = signature.parameters.filter((arg: Argument) => {
                             return arg.dataTypeComponentUri && arg.dataTypeRange && arg.dataTypeRange.contains(position);
                         });
 
-                        await Promise.all(parameters.map((arg: Argument) => {
+                        parameters.map((arg: Argument) => {
                             const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                             if (argTypeComp) {
                                 results.push({
@@ -145,8 +145,8 @@ export default class CFMLDefinitionProvider implements DefinitionProvider {
                                     targetSelectionRange: argTypeComp.declarationRange
                                 });
                             }
-                        }));
-                    }));
+                        });
+                    });
 
                     if (func.bodyRange && func.bodyRange.contains(position)) {
                         // Local variable uses

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -453,13 +453,13 @@ export default class CFMLHoverProvider implements HoverProvider {
      * @param range An optional range to which this hover applies
      * @returns
      */
-    public async createHover(definition: HoverProviderItem, range?: Range): Promise<Hover> {
+    public createHover(definition: HoverProviderItem, range?: Range): Hover {
         if (!definition) {
-            return Promise.reject(new Error("Definition not found"));
+            throw new Error("Definition not found");
         }
 
         if (!definition.name) {
-            return Promise.reject(new Error("Invalid definition format"));
+            throw new Error("Invalid definition format");
         }
 
         return new Hover(this.createHoverText(definition), range);

--- a/src/features/typeDefinitionProvider.ts
+++ b/src/features/typeDefinitionProvider.ts
@@ -49,12 +49,12 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 // Component functions (related)
                 for (const [, func] of thisComponent.functions) {
                     // Argument declarations
-                    await Promise.all(func.signatures.map(async (signature: UserFunctionSignature) => {
+                    func.signatures.map((signature: UserFunctionSignature) => {
                         const signatureparameters = signature.parameters.filter((arg: Argument) => {
                             return arg.dataTypeComponentUri && arg.nameRange && arg.nameRange.contains(position);
                         })
 
-                        await Promise.all(signatureparameters.map((arg: Argument) => {
+                        signatureparameters.map((arg: Argument) => {
                             const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                             if (argTypeComp) {
                                 results.push(new Location(
@@ -62,8 +62,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                                     argTypeComp.declarationRange
                                 ));
                             }
-                        }));
-                    }));
+                        });
+                    });
 
                     if (func.bodyRange && func.bodyRange.contains(position)) {
                         // Local variable uses
@@ -73,7 +73,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                             const localVariablesfiltered = localVariables.filter((localVar: Variable) => {
                                 return position.isAfterOrEqual(localVar.declarationLocation.range.start) && equalsIgnoreCase(localVar.identifier, currentWord) && localVar.dataTypeComponentUri;
                             });
-                            await Promise.all(localVariablesfiltered.map((localVar: Variable) => {
+                            localVariablesfiltered.map((localVar: Variable) => {
                                 const localVarTypeComp: Component = getComponent(localVar.dataTypeComponentUri, _token);
                                 if (localVarTypeComp) {
                                     results.push(new Location(
@@ -81,18 +81,18 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                                         localVarTypeComp.declarationRange
                                     ));
                                 }
-                            }));
+                            });
                         }
 
                         // Argument uses
                         if (results.length === 0) {
                             const argumentPrefixPattern = getValidScopesPrefixPattern([Scope.Arguments], true);
                             if (argumentPrefixPattern.test(docPrefix)) {
-                                await Promise.all(func.signatures.map(async (signature: UserFunctionSignature) => {
+                                func.signatures.map((signature: UserFunctionSignature) => {
                                     const signatureparameters = signature.parameters.filter((arg: Argument) => {
                                         return equalsIgnoreCase(arg.name, currentWord) && arg.dataTypeComponentUri;
                                     });
-                                    await Promise.all(signatureparameters.map((arg: Argument) => {
+                                    signatureparameters.map((arg: Argument) => {
                                         const argTypeComp: Component = getComponent(arg.dataTypeComponentUri, _token);
                                         if (argTypeComp) {
                                             results.push(new Location(
@@ -100,8 +100,8 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                                                 argTypeComp.declarationRange
                                             ));
                                         }
-                                    }));
-                                }));
+                                    });
+                                });
                             }
                         }
                     }
@@ -129,7 +129,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                     const thisComponentvariables = thisComponent.variables.filter((variable: Variable) => {
                         return equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
                     });
-                    await Promise.all(thisComponentvariables.map((variable: Variable) => {
+                    thisComponentvariables.map((variable: Variable) => {
                         const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                         if (varTypeComp) {
                             results.push(new Location(
@@ -137,7 +137,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                                 varTypeComp.declarationRange
                             ));
                         }
-                    }));
+                    });
                 }
             }
         } else if (docIsCfmFile) {
@@ -163,7 +163,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                     return (unscopedPrecedence.includes(variable.scope) || variable.scope === Scope.Unknown);
                 });
 
-                await Promise.all(docVariableAssignmentsfiltered.map((variable: Variable) => {
+                docVariableAssignmentsfiltered.map((variable: Variable) => {
                     const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                     if (varTypeComp) {
                         results.push(new Location(
@@ -171,7 +171,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                             varTypeComp.declarationRange
                         ));
                     }
-                }));
+                });
             }
         }
 
@@ -198,7 +198,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 return variable.scope === currentScope && equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
             });
 
-            await Promise.all(applicationDocVariablesfiltered.map((variable: Variable) => {
+            applicationDocVariablesfiltered.map((variable: Variable) => {
                 const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                 if (varTypeComp) {
                     results.push(new Location(
@@ -206,7 +206,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                         varTypeComp.declarationRange
                     ));
                 }
-            }));
+            });
         }
 
         // Server variables
@@ -217,7 +217,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                 return variable.scope === Scope.Server && equalsIgnoreCase(variable.identifier, currentWord) && variable.dataTypeComponentUri;
             });
 
-            await Promise.all(serverDocVariablesfiltered.map((variable: Variable) => {
+            serverDocVariablesfiltered.map((variable: Variable) => {
                 const varTypeComp: Component = getComponent(variable.dataTypeComponentUri, _token);
                 if (varTypeComp) {
                     results.push(new Location(
@@ -225,7 +225,7 @@ export default class CFMLTypeDefinitionProvider implements TypeDefinitionProvide
                         varTypeComp.declarationRange
                     ));
                 }
-            }));
+            });
         }
 
         return results;

--- a/src/utils/snippetService.ts
+++ b/src/utils/snippetService.ts
@@ -21,35 +21,18 @@ export default class SnippetService {
      * @returns Snippets
      */
     public static async getCustomSnippets(): Promise<Snippets> {
+        const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest");
+        const snippetsLocalPath: string = cfmlCompletionSettings.get("snippets.localPath");
 
-        return new Promise<Snippets>((resolve, reject) => {
-
-            const cfmlCompletionSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.suggest");
-
-            const snippetsLocalPath: string = cfmlCompletionSettings.get("snippets.localPath");
-
-            if ( snippetsLocalPath && snippetsLocalPath.length > 0 ) {
-
-                const snippetsPathUri: Uri = Uri.file(snippetsLocalPath);
-
-                try {
-                    workspace.fs.readFile(snippetsPathUri).then((readData) => {
-                        const readStr = Buffer.from(readData).toString("utf8");
-                        const readJson = JSON.parse(readStr);
-                        resolve(readJson);
-                    });
-                } catch (ex) {
-                    reject(ex);
-                }
-
-            } else {
-
-                resolve({});
-
-            }
-
-        });
-
+        if (snippetsLocalPath && snippetsLocalPath.length > 0) {
+            const snippetsPathUri: Uri = Uri.file(snippetsLocalPath);
+            const readData = await workspace.fs.readFile(snippetsPathUri);
+            const readStr = Buffer.from(readData).toString("utf8");
+            const readJson = JSON.parse(readStr) as Snippets;
+            return readJson;
+        } else {
+            return {};
+        }
     }
 
 }


### PR DESCRIPTION
## Fixes

- Fix parse error with destructuring assignment, and ensure such errors are logged properly
- Fix VS Code warning dialog "There are task errors" by updating eslint problem matcher
- Fix "Go to Definition" not working if the reference was cached before the definition

## Maintenance

- Removed `promise.all` without async functions
- Replace promise syntax with await
- Remove recommended extension that was deprecated after VS Code implemented it natively
