### PR TITLE
Fix null check while regex

### DIFF
--- a/src/entities/attribute.ts
+++ b/src/entities/attribute.ts
@@ -50,9 +50,8 @@ export function getAttributePattern(attributeName: string): RegExp {
 export function parseAttributes(document: TextDocument, attributeRange: Range, validAttributeNames?: MySet<string>): Attributes {
 	const attributeStr: string = document.getText(attributeRange);
 	const attributes: Attributes = new Attributes();
-	let attributeMatch: RegExpExecArray = null;
-	// eslint-disable-next-line no-cond-assign
-	while (attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr)) {
+	let attributeMatch: RegExpExecArray | null;
+	while ((attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr))) {
 		const attributeName = attributeMatch[1];
 		if (validAttributeNames && !validAttributeNames.has(attributeName.toLowerCase())) {
 			continue;

--- a/src/entities/catch.ts
+++ b/src/entities/catch.ts
@@ -115,8 +115,7 @@ export function parseCatches(documentStateContext: DocumentStateContext, isScrip
 
 	if (isScript) {
 		let scriptCatchMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (scriptCatchMatch = scriptCatchPattern.exec(documentText)) {
+		while ((scriptCatchMatch = scriptCatchPattern.exec(documentText))) {
 			const catchType = scriptCatchMatch[1] ? scriptCatchMatch[1] : "any";
 			const catchVariable = scriptCatchMatch[2];
 

--- a/src/entities/catch.ts
+++ b/src/entities/catch.ts
@@ -114,7 +114,7 @@ export function parseCatches(documentStateContext: DocumentStateContext, isScrip
 	}
 
 	if (isScript) {
-		let scriptCatchMatch: RegExpExecArray = null;
+		let scriptCatchMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (scriptCatchMatch = scriptCatchPattern.exec(documentText)) {
 			const catchType = scriptCatchMatch[1] ? scriptCatchMatch[1] : "any";

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -180,7 +180,7 @@ export async function parseComponent(documentStateContext: DocumentStateContext,
 	const documentText: string = document.getText();
 	const componentIsScript: boolean = documentStateContext.docIsScript;
 
-	let componentMatch: RegExpExecArray;
+	let componentMatch: RegExpExecArray | null;
 	let head: string;
 	let attributePrefix: string;
 	let fullPrefix: string | undefined;

--- a/src/entities/docblock.ts
+++ b/src/entities/docblock.ts
@@ -26,7 +26,7 @@ export function parseDocBlock(document: TextDocument, docRange: Range): DocBlock
 	let activeValue = undefined;
 	let activeValueStartOffset = 0;
 	let activeValueEndOffset = 0;
-	let docBlockMatches: RegExpExecArray = null;
+	let docBlockMatches: RegExpExecArray | null;
 	const docBlockOffset: number = document.offsetAt(docRange.start);
 	// eslint-disable-next-line no-cond-assign
 	while (docBlockMatches = DOC_PATTERN.exec(docBlockStr)) {

--- a/src/entities/docblock.ts
+++ b/src/entities/docblock.ts
@@ -28,8 +28,7 @@ export function parseDocBlock(document: TextDocument, docRange: Range): DocBlock
 	let activeValueEndOffset = 0;
 	let docBlockMatches: RegExpExecArray | null;
 	const docBlockOffset: number = document.offsetAt(docRange.start);
-	// eslint-disable-next-line no-cond-assign
-	while (docBlockMatches = DOC_PATTERN.exec(docBlockStr)) {
+	while ((docBlockMatches = DOC_PATTERN.exec(docBlockStr))) {
 		const valuePrefix: string = docBlockMatches[1];
 		const metadataKey: string = docBlockMatches[2];
 		const metadataSubkey: string = docBlockMatches[3];

--- a/src/entities/globals.ts
+++ b/src/entities/globals.ts
@@ -61,8 +61,7 @@ export function globalTagSyntaxToScript(globalTag: GlobalTag): string {
 	const attributeStr: string = cfStartTagPattern.exec(globalTag.syntax)[3];
 	if (attributeStr) {
 		let attributeMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr)) {
+		while ((attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr))) {
 			attributes.push(attributeMatch[0]);
 		}
 	}

--- a/src/entities/globals.ts
+++ b/src/entities/globals.ts
@@ -60,7 +60,7 @@ export function globalTagSyntaxToScript(globalTag: GlobalTag): string {
 	const cfStartTagPattern = getCfStartTagPattern();
 	const attributeStr: string = cfStartTagPattern.exec(globalTag.syntax)[3];
 	if (attributeStr) {
-		let attributeMatch: RegExpExecArray = null;
+		let attributeMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr)) {
 			attributes.push(attributeMatch[0]);

--- a/src/entities/property.ts
+++ b/src/entities/property.ts
@@ -52,8 +52,7 @@ export async function parseProperties(documentStateContext: DocumentStateContext
 	const document: TextDocument = documentStateContext.document;
 	const componentText: string = document.getText();
 	let propertyMatch: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (propertyMatch = propertyPattern.exec(componentText)) {
+	while ((propertyMatch = propertyPattern.exec(componentText))) {
 		const propertyAttributePrefix: string = propertyMatch[1];
 		const propertyFullDoc: string = propertyMatch[2];
 		const propertyDocContent: string = propertyMatch[3];

--- a/src/entities/property.ts
+++ b/src/entities/property.ts
@@ -51,7 +51,7 @@ export async function parseProperties(documentStateContext: DocumentStateContext
 	const properties: Properties = new Properties();
 	const document: TextDocument = documentStateContext.document;
 	const componentText: string = document.getText();
-	let propertyMatch: RegExpExecArray = null;
+	let propertyMatch: RegExpExecArray | null;
 	// eslint-disable-next-line no-cond-assign
 	while (propertyMatch = propertyPattern.exec(componentText)) {
 		const propertyAttributePrefix: string = propertyMatch[1];

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -611,8 +611,7 @@ export function parseTags(documentStateContext: DocumentStateContext, tagName: s
 
 	const thisTagPattern: RegExp = getTagPattern(tagName);
 	let thisTagMatch: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (thisTagMatch = thisTagPattern.exec(documentText)) {
+	while ((thisTagMatch = thisTagPattern.exec(documentText))) {
 		const tagStart: string = thisTagMatch[1];
 		const tagAttributes: string = thisTagMatch[2];
 		const tagBodyText: string = thisTagMatch[3];
@@ -669,8 +668,7 @@ export function parseStartTags(documentStateContext: DocumentStateContext, tagNa
 
 	const thisTagPattern: RegExp = isScript ? getStartScriptTagPattern(tagName) : getStartTagPattern(tagName);
 	let thisTagMatch: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (thisTagMatch = thisTagPattern.exec(documentText)) {
+	while ((thisTagMatch = thisTagPattern.exec(documentText))) {
 		const fullMatch: string = thisTagMatch[0];
 		const tagStart: string = thisTagMatch[1];
 		const tagAttributes: string = thisTagMatch[2];

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -610,7 +610,7 @@ export function parseTags(documentStateContext: DocumentStateContext, tagName: s
 	}
 
 	const thisTagPattern: RegExp = getTagPattern(tagName);
-	let thisTagMatch: RegExpExecArray = null;
+	let thisTagMatch: RegExpExecArray | null;
 	// eslint-disable-next-line no-cond-assign
 	while (thisTagMatch = thisTagPattern.exec(documentText)) {
 		const tagStart: string = thisTagMatch[1];
@@ -668,7 +668,7 @@ export function parseStartTags(documentStateContext: DocumentStateContext, tagNa
 	}
 
 	const thisTagPattern: RegExp = isScript ? getStartScriptTagPattern(tagName) : getStartTagPattern(tagName);
-	let thisTagMatch: RegExpExecArray = null;
+	let thisTagMatch: RegExpExecArray | null;
 	// eslint-disable-next-line no-cond-assign
 	while (thisTagMatch = thisTagPattern.exec(documentText)) {
 		const fullMatch: string = thisTagMatch[0];

--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -179,7 +179,7 @@ export async function parseScriptFunctions(documentStateContext: DocumentStateCo
 	const userFunctions: UserFunction[] = [];
 	// sanitizedDocumentText removes doc blocks
 	const componentBody: string = documentStateContext.sanitizedDocumentText;
-	let scriptFunctionMatch: RegExpExecArray = null;
+	let scriptFunctionMatch: RegExpExecArray | null;
 	// eslint-disable-next-line no-cond-assign
 	while (scriptFunctionMatch = scriptFunctionPattern.exec(componentBody)) {
 		const fullMatch: string = scriptFunctionMatch[0];

--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -180,8 +180,7 @@ export async function parseScriptFunctions(documentStateContext: DocumentStateCo
 	// sanitizedDocumentText removes doc blocks
 	const componentBody: string = documentStateContext.sanitizedDocumentText;
 	let scriptFunctionMatch: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (scriptFunctionMatch = scriptFunctionPattern.exec(componentBody)) {
+	while ((scriptFunctionMatch = scriptFunctionPattern.exec(componentBody))) {
 		const fullMatch: string = scriptFunctionMatch[0];
 		const returnTypePrefix: string = scriptFunctionMatch[1];
 		const fullDocBlock: string = scriptFunctionMatch[2];

--- a/src/entities/variable.ts
+++ b/src/entities/variable.ts
@@ -364,7 +364,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	}
 
 	// params
-	let paramMatch: RegExpExecArray = null;
+	let paramMatch: RegExpExecArray | null;
 	const paramPattern: RegExp = isScript ? scriptParamPattern : tagParamPattern;
 	// eslint-disable-next-line no-cond-assign
 	while (paramMatch = paramPattern.exec(documentText)) {
@@ -443,7 +443,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	}
 
 	// variable assignments
-	let variableMatch: RegExpExecArray = null;
+	let variableMatch: RegExpExecArray | null;
 	const variableAssignmentPattern: RegExp = isScript ? cfscriptVariableAssignmentPattern : tagVariableAssignmentPattern;
 	// eslint-disable-next-line no-cond-assign
 	while (variableMatch = variableAssignmentPattern.exec(documentText)) {
@@ -500,7 +500,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 		};
 
 		if (dataType === DataType.Query) {
-			let valueMatch: RegExpExecArray = null;
+			let valueMatch: RegExpExecArray | null;
 			// eslint-disable-next-line no-cond-assign
 			if (valueMatch = queryValuePattern.exec(initValue)) {
 				const fullValueMatch: string = valueMatch[0];
@@ -536,7 +536,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 		else if (dataType === DataType.Function) {
 			const userFunction: UserFunctionVariable = thisVar as UserFunctionVariable;
 
-			let valueMatch: RegExpExecArray = null;
+			let valueMatch: RegExpExecArray | null;
 			// eslint-disable-next-line no-cond-assign
 			if (valueMatch = functionValuePattern.exec(initValue)) {
 				const fullValueMatch: string = valueMatch[0];
@@ -564,7 +564,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	if (!isScript || userEngine.supportsScriptTags()) {
 		// Tags with output attributes
 		const foundOutputVarTags: MySet<string> = new MySet();
-		let cfTagMatch: RegExpExecArray = null;
+		let cfTagMatch: RegExpExecArray | null;
 		const cfTagPattern: RegExp = isScript ? getCfScriptTagPatternIgnoreBody() : getCfStartTagPattern();
 		// eslint-disable-next-line no-cond-assign
 		while (cfTagMatch = cfTagPattern.exec(documentText)) {
@@ -679,7 +679,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	}
 	else {
 		// Check for-in loops
-		let forInVariableMatch: RegExpExecArray = null;
+		let forInVariableMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (forInVariableMatch = forInVariableAssignmentPattern.exec(documentText)) {
 			const varPrefix: string = forInVariableMatch[1];

--- a/src/entities/variable.ts
+++ b/src/entities/variable.ts
@@ -366,8 +366,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	// params
 	let paramMatch: RegExpExecArray | null;
 	const paramPattern: RegExp = isScript ? scriptParamPattern : tagParamPattern;
-	// eslint-disable-next-line no-cond-assign
-	while (paramMatch = paramPattern.exec(documentText)) {
+	while ((paramMatch = paramPattern.exec(documentText))) {
 		const paramPrefix: string = paramMatch[1];
 		const paramAttr: string = paramMatch[2];
 
@@ -445,8 +444,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	// variable assignments
 	let variableMatch: RegExpExecArray | null;
 	const variableAssignmentPattern: RegExp = isScript ? cfscriptVariableAssignmentPattern : tagVariableAssignmentPattern;
-	// eslint-disable-next-line no-cond-assign
-	while (variableMatch = variableAssignmentPattern.exec(documentText)) {
+	while ((variableMatch = variableAssignmentPattern.exec(documentText))) {
 		const initValuePrefix: string = variableMatch[1];
 		const varPrefix: string = variableMatch[2];
 		const varScope: string = variableMatch[3];
@@ -500,9 +498,8 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 		};
 
 		if (dataType === DataType.Query) {
-			let valueMatch: RegExpExecArray | null;
-			// eslint-disable-next-line no-cond-assign
-			if (valueMatch = queryValuePattern.exec(initValue)) {
+			const valueMatch = queryValuePattern.exec(initValue);
+			if (valueMatch) {
 				const fullValueMatch: string = valueMatch[0];
 				const functionName: string = valueMatch[1];
 
@@ -536,9 +533,8 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 		else if (dataType === DataType.Function) {
 			const userFunction: UserFunctionVariable = thisVar as UserFunctionVariable;
 
-			let valueMatch: RegExpExecArray | null;
-			// eslint-disable-next-line no-cond-assign
-			if (valueMatch = functionValuePattern.exec(initValue)) {
+			const valueMatch = functionValuePattern.exec(initValue);
+			if (valueMatch) {
 				const fullValueMatch: string = valueMatch[0];
 
 				const initValueOffset = textOffset + variableMatch.index + initValuePrefix.length;
@@ -566,8 +562,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 		const foundOutputVarTags: MySet<string> = new MySet();
 		let cfTagMatch: RegExpExecArray | null;
 		const cfTagPattern: RegExp = isScript ? getCfScriptTagPatternIgnoreBody() : getCfStartTagPattern();
-		// eslint-disable-next-line no-cond-assign
-		while (cfTagMatch = cfTagPattern.exec(documentText)) {
+		while ((cfTagMatch = cfTagPattern.exec(documentText))) {
 			const tagName = cfTagMatch[2].toLowerCase();
 			if (!foundOutputVarTags.has(tagName) && Object.prototype.hasOwnProperty.call(outputVariableTags, tagName)) {
 				foundOutputVarTags.add(tagName);
@@ -680,8 +675,7 @@ export async function parseVariableAssignments(documentStateContext: DocumentSta
 	else {
 		// Check for-in loops
 		let forInVariableMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (forInVariableMatch = forInVariableAssignmentPattern.exec(documentText)) {
+		while ((forInVariableMatch = forInVariableAssignmentPattern.exec(documentText))) {
 			const varPrefix: string = forInVariableMatch[1];
 			const varScope: string = forInVariableMatch[2];
 			const scope: string = forInVariableMatch[3];

--- a/src/features/colorProvider.ts
+++ b/src/features/colorProvider.ts
@@ -32,7 +32,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 		for (const cssRange of cssRanges) {
 			const rangeTextOffset: number = document.offsetAt(cssRange.start);
 			const rangeText: string = documentStateContext.sanitizedDocumentText.slice(rangeTextOffset, document.offsetAt(cssRange.end));
-			let propertyMatch: RegExpExecArray;
+			let propertyMatch: RegExpExecArray | null;
 			// eslint-disable-next-line no-cond-assign
 			while (propertyMatch = cssPropertyPattern.exec(rangeText)) {
 				const propertyValuePrefix: string = propertyMatch[1];
@@ -45,7 +45,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 
 				const cssProperty: IPropertyData = cssDataManager.getProperty(propertyName);
 				if (cssProperty.restrictions && cssProperty.restrictions.includes("color")) {
-					let colorMatch: RegExpExecArray;
+					let colorMatch: RegExpExecArray | null;
 
 					// RGB hex
 					// eslint-disable-next-line no-cond-assign

--- a/src/features/colorProvider.ts
+++ b/src/features/colorProvider.ts
@@ -33,8 +33,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 			const rangeTextOffset: number = document.offsetAt(cssRange.start);
 			const rangeText: string = documentStateContext.sanitizedDocumentText.slice(rangeTextOffset, document.offsetAt(cssRange.end));
 			let propertyMatch: RegExpExecArray | null;
-			// eslint-disable-next-line no-cond-assign
-			while (propertyMatch = cssPropertyPattern.exec(rangeText)) {
+			while ((propertyMatch = cssPropertyPattern.exec(rangeText))) {
 				const propertyValuePrefix: string = propertyMatch[1];
 				const propertyName: string = propertyMatch[2];
 				const propertyValue: string = propertyMatch[3];
@@ -48,8 +47,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 					let colorMatch: RegExpExecArray | null;
 
 					// RGB hex
-					// eslint-disable-next-line no-cond-assign
-					while (colorMatch = rgbHexPattern.exec(propertyValue)) {
+					while ((colorMatch = rgbHexPattern.exec(propertyValue))) {
 						const rgbHexValue: string = colorMatch[1];
 						const colorRange: Range = new Range(
 							document.positionAt(rangeTextOffset + propertyMatch.index + propertyValuePrefix.length + colorMatch.index),
@@ -60,8 +58,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 					}
 
 					// RGB function
-					// eslint-disable-next-line no-cond-assign
-					while (colorMatch = rgbFuncPattern.exec(propertyValue)) {
+					while ((colorMatch = rgbFuncPattern.exec(propertyValue))) {
 						const r: string = colorMatch[1];
 						const g: string = colorMatch[2];
 						const b: string = colorMatch[3];
@@ -86,8 +83,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 					}
 
 					// HSL function
-					// eslint-disable-next-line no-cond-assign
-					while (colorMatch = hslFuncPattern.exec(propertyValue)) {
+					while ((colorMatch = hslFuncPattern.exec(propertyValue))) {
 						const h: string = colorMatch[1];
 						const hUnit: string = colorMatch[2];
 						const s: string = colorMatch[3];
@@ -114,8 +110,7 @@ export default class CFMLDocumentColorProvider implements DocumentColorProvider 
 					}
 
 					// Color keywords
-					// eslint-disable-next-line no-cond-assign
-					while (colorMatch = colorKeywordPattern.exec(propertyValue)) {
+					while ((colorMatch = colorKeywordPattern.exec(propertyValue))) {
 						const keywordPrefix: string = colorMatch[1];
 						const colorKeyword: string = colorMatch[2].toLowerCase();
 						const colorRange: Range = new Range(

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -187,8 +187,7 @@ export default class CFMLHoverProvider implements HoverProvider {
 				const rangeTextOffset: number = document.offsetAt(cssRange.start);
 				const rangeText: string = documentPositionStateContext.sanitizedDocumentText.slice(rangeTextOffset, document.offsetAt(cssRange.end));
 				let propertyMatch: RegExpExecArray | null;
-				// eslint-disable-next-line no-cond-assign
-				while (propertyMatch = cssPropertyPattern.exec(rangeText)) {
+				while ((propertyMatch = cssPropertyPattern.exec(rangeText))) {
 					const propertyName: string = propertyMatch[2];
 
 					const propertyRange: Range = new Range(

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -186,7 +186,7 @@ export default class CFMLHoverProvider implements HoverProvider {
 
 				const rangeTextOffset: number = document.offsetAt(cssRange.start);
 				const rangeText: string = documentPositionStateContext.sanitizedDocumentText.slice(rangeTextOffset, document.offsetAt(cssRange.end));
-				let propertyMatch: RegExpExecArray;
+				let propertyMatch: RegExpExecArray | null;
 				// eslint-disable-next-line no-cond-assign
 				while (propertyMatch = cssPropertyPattern.exec(rangeText)) {
 					const propertyName: string = propertyMatch[2];

--- a/src/features/signatureHelpProvider.ts
+++ b/src/features/signatureHelpProvider.ts
@@ -175,9 +175,8 @@ export default class CFMLSignatureHelpProvider implements SignatureHelpProvider 
 		}
 
 		// Consider named parameters
-		let namedParamMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		if (namedParamMatch = namedParameterPattern.exec(paramText)) {
+		const namedParamMatch = namedParameterPattern.exec(paramText);
+		if (namedParamMatch) {
 			// TODO: Consider argumentCollection
 			const paramName: string = namedParamMatch[1];
 			const namedParamIndex: number = entry.signatures[sigHelp.activeSignature].parameters.findIndex((param: Parameter) => {

--- a/src/features/signatureHelpProvider.ts
+++ b/src/features/signatureHelpProvider.ts
@@ -175,7 +175,7 @@ export default class CFMLSignatureHelpProvider implements SignatureHelpProvider 
 		}
 
 		// Consider named parameters
-		let namedParamMatch: RegExpExecArray = null;
+		let namedParamMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		if (namedParamMatch = namedParameterPattern.exec(paramText)) {
 			// TODO: Consider argumentCollection

--- a/src/utils/contextUtil.ts
+++ b/src/utils/contextUtil.ts
@@ -247,7 +247,7 @@ export function getCfScriptRanges(document: TextDocument, range: Range, _token: 
 	}
 
 	const cfscriptTagPattern: RegExp = getTagPattern("cfscript");
-	let cfscriptTagMatch: RegExpExecArray = null;
+	let cfscriptTagMatch: RegExpExecArray | null;
 	// eslint-disable-next-line no-cond-assign
 	while (cfscriptTagMatch = cfscriptTagPattern.exec(documentText)) {
 		const prefixLen: number = cfscriptTagMatch[1].length + cfscriptTagMatch[2].length + 1;
@@ -311,7 +311,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 	}
 
 	if (isScript) {
-		let scriptBlockCommentMatch: RegExpExecArray = null;
+		let scriptBlockCommentMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (scriptBlockCommentMatch = cfscriptBlockCommentPattern.exec(documentText)) {
 			const scriptBlockCommentText: string = scriptBlockCommentMatch[0];
@@ -322,7 +322,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 			));
 		}
 
-		let scriptLineCommentMatch: RegExpExecArray = null;
+		let scriptLineCommentMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (scriptLineCommentMatch = cfscriptLineCommentPattern.exec(documentText)) {
 			const scriptLineCommentText = scriptLineCommentMatch[0];
@@ -334,7 +334,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 		}
 	}
 	else {
-		let tagBlockCommentMatch: RegExpExecArray = null;
+		let tagBlockCommentMatch: RegExpExecArray | null;
 		// eslint-disable-next-line no-cond-assign
 		while (tagBlockCommentMatch = tagBlockCommentPattern.exec(documentText)) {
 			const tagBlockCommentText = tagBlockCommentMatch[0];

--- a/src/utils/contextUtil.ts
+++ b/src/utils/contextUtil.ts
@@ -248,8 +248,7 @@ export function getCfScriptRanges(document: TextDocument, range: Range, _token: 
 
 	const cfscriptTagPattern: RegExp = getTagPattern("cfscript");
 	let cfscriptTagMatch: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (cfscriptTagMatch = cfscriptTagPattern.exec(documentText)) {
+	while ((cfscriptTagMatch = cfscriptTagPattern.exec(documentText))) {
 		const prefixLen: number = cfscriptTagMatch[1].length + cfscriptTagMatch[2].length + 1;
 		const cfscriptBodyText: string = cfscriptTagMatch[3];
 		if (cfscriptBodyText) {
@@ -312,8 +311,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 
 	if (isScript) {
 		let scriptBlockCommentMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (scriptBlockCommentMatch = cfscriptBlockCommentPattern.exec(documentText)) {
+		while ((scriptBlockCommentMatch = cfscriptBlockCommentPattern.exec(documentText))) {
 			const scriptBlockCommentText: string = scriptBlockCommentMatch[0];
 			const scriptBlockCommentStartOffset: number = textOffset + scriptBlockCommentMatch.index;
 			commentRanges.push(new Range(
@@ -323,8 +321,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 		}
 
 		let scriptLineCommentMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (scriptLineCommentMatch = cfscriptLineCommentPattern.exec(documentText)) {
+		while ((scriptLineCommentMatch = cfscriptLineCommentPattern.exec(documentText))) {
 			const scriptLineCommentText = scriptLineCommentMatch[0];
 			const scriptLineCommentStartOffset = textOffset + scriptLineCommentMatch.index;
 			commentRanges.push(new Range(
@@ -335,8 +332,7 @@ function getCommentRangesByRegex(document: TextDocument, isScript: boolean = fal
 	}
 	else {
 		let tagBlockCommentMatch: RegExpExecArray | null;
-		// eslint-disable-next-line no-cond-assign
-		while (tagBlockCommentMatch = tagBlockCommentPattern.exec(documentText)) {
+		while ((tagBlockCommentMatch = tagBlockCommentPattern.exec(documentText))) {
 			const tagBlockCommentText = tagBlockCommentMatch[0];
 			const tagBlockCommentStartOffset = textOffset + tagBlockCommentMatch.index;
 			commentRanges.push(new Range(

--- a/src/utils/wordHelpers.ts
+++ b/src/utils/wordHelpers.ts
@@ -76,8 +76,7 @@ export function getWordAtText(column: number, wordDefinition: RegExp, text: stri
 
 function _findRegexMatchEnclosingPosition(wordDefinition: RegExp, text: string, pos: number, stopPos: number): RegExpExecArray | null {
 	let match: RegExpExecArray | null;
-	// eslint-disable-next-line no-cond-assign
-	while (match = wordDefinition.exec(text)) {
+	while ((match = wordDefinition.exec(text))) {
 		if (match.index <= pos && wordDefinition.lastIndex >= pos) {
 			break;
 		}


### PR DESCRIPTION
Here's my attempt at chipping away at the `strictNullChecks` errors.

Change 1
```
// cannot assign null to RegExpExecArray
- let scriptCatchMatch: RegExpExecArray = null;
+ let scriptCatchMatch: RegExpExecArray | null;
```

Change 2
```
- // eslint-disable-next-line no-cond-assign
- while (attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr)) {
+ while ((attributeMatch = ATTRIBUTES_PATTERN.exec(attributeStr))) {

