### PR TITLE
Fix default formatter running before ESLint Stylistic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,15 @@
 	"cSpell.words": [
 		"struct"
 	],
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"editor.codeActionsOnSave": {
-		"source.fixAll": "always"
-	}
+		"source.fixAll": "explicit"
+	},
+	"eslint.rules.customizations": [
+		{
+			"rule": "@stylistic/*",
+			"fixable": true,
+			"severity": "off"
+		}
+	]
 }


### PR DESCRIPTION
With `formatOnSave:true`, the default formatter modifies the file before ESLint Stylistic can.

An opinionated formatted like Prettier will completely change all of the whitespace. When ESLint Stylistic formats the file it will respect the whitespace changes deferring to developer intent. This leads to significant undesirable changes on save.

- Changed  `formatOnSave` to `false` to fix this
- Changed `source.fixAll` to `explicit` which is recommended by https://eslint.style/guide/faq#vs-code
- Turned off highlighting for Stylistic errors, as they are very noisy and are fixed on save anyway