### PR TITLE
Fix docblocks not being parsed

### DIFF
--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -178,8 +178,8 @@ export interface UserFunctionsByName {
 export async function parseScriptFunctions(documentStateContext: DocumentStateContext, _token: CancellationToken | undefined): Promise<UserFunction[]> {
 	const document: TextDocument = documentStateContext.document;
 	const userFunctions: UserFunction[] = [];
-	// sanitizedDocumentText removes doc blocks
-	const componentBody: string = documentStateContext.sanitizedDocumentText;
+	// We need to parse doc blocks from comments here, so we cannot use documentStateContext.sanitizedDocumentText
+	const componentBody: string = document.getText();
 	let scriptFunctionMatch: RegExpExecArray | null;
 	while ((scriptFunctionMatch = scriptFunctionPattern.exec(componentBody))) {
 		const fullMatch: string = scriptFunctionMatch[0];

--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -518,11 +518,11 @@ export async function parseScriptFunctionArgs(documentStateContext: DocumentStat
 				}));
 			}
 
-			docBlock = docBlock.filter((docElem: DocBlockKeyValue) => {
+			const matchingDocBlocks = docBlock.filter((docElem: DocBlockKeyValue) => {
 				return equalsIgnoreCase(docElem.key, argument.name);
 			});
 
-			await Promise.all(docBlock.map(async (docElem: DocBlockKeyValue) => {
+			await Promise.all(matchingDocBlocks.map(async (docElem: DocBlockKeyValue) => {
 				if (docElem.subkey === "required") {
 					argument.required = DataType.isTruthy(docElem.value);
 				}


### PR DESCRIPTION
This reverts a previous change that broke docblock functionality by parsing the component body with all comments removed.

Fixes #76 