### PR TITLE
Add a setting to change the web root

### DIFF
--- a/package.json
+++ b/package.json
@@ -495,7 +495,13 @@
 							"directoryPath"
 						]
 					},
-					"description": "Represents CFML mappings from logicalPath to directoryPath.",
+					"markdownDescription": "Represents CFML mappings from logicalPath to directoryPath.\n\nIf paths are relative to a subfolder instead of the workspace root, see `#cfml.webRoot#`.",
+					"scope": "resource"
+				},
+				"cfml.webRoot": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "A subfolder used as the web root by the ColdFusion/Lucee server.\n\nTypically this will be blank, or a subfolder like `public`, `www`, `src`, or wherever the main `Application.cfc` is located.\n\nUse in conjunction with `#cfml.mappings#` to resolve component paths.",
 					"scope": "resource"
 				}
 			}

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -267,6 +267,10 @@ export async function activate(context: ExtensionContext): Promise<api> {
 		if (evt.affectsConfiguration("cfml.globalDefinitions") || evt.affectsConfiguration("cfml.cfDocs") || evt.affectsConfiguration("cfml.engine")) {
 			commands.executeCommand("cfml.refreshGlobalDefinitionCache");
 		}
+		if (evt.affectsConfiguration("cfml.mappings") || evt.affectsConfiguration("cfml.webRoot")) {
+			// Refresh cached components so the config changes take effect
+			commands.executeCommand("cfml.refreshWorkspaceDefinitionCache");
+		}
 	}));
 
 	const cfmlSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml");

--- a/src/features/cachedEntities.ts
+++ b/src/features/cachedEntities.ts
@@ -410,6 +410,9 @@ async function cacheGivenComponents(componentUris: Uri[], _token: CancellationTo
 				if (token.isCancellationRequested) {
 					break;
 				}
+				if (_token && _token.isCancellationRequested) {
+					break;
+				}
 
 				try {
 					const document: TextDocument = await LSTextDocument.openTextDocument(componentUri);

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -198,7 +198,11 @@ export function resolveRootPath(baseUri: Uri, appendingPath: string): string | u
 		return undefined;
 	}
 
-	return Uri.joinPath(root.uri, appendingPath).fsPath;
+	// Include the webroot (relative to the workspace root)
+	// Used when the application is served from a subdirectory ("public", "www", "src", etc...)
+	const webRoot = workspace.getConfiguration("cfml", baseUri).get<string>("webRoot", "");
+
+	return Uri.joinPath(root.uri, webRoot, appendingPath).fsPath;
 }
 
 /**


### PR DESCRIPTION
The code currently treats the workspace root as the web root. If the ColdFusion/Lucee server uses a subfolder instead, then we should allow setting that as the web root.

Without this, component names that are relative to the web root won't be found. A workaround is adding custom mappings for each child folder of the web root. These are mappings that are not needed on the server.

Closes #36 

The mappings and webRoot settings are applied and then cached. Because of this, any settings changes won't take effect until the workspace definitions are refreshed. It's likely that devs will get frustrated and restart/reload VSCode trying to get the settings to take effect.

To avoid this issue I've made the refresh happen automatically. This created another issue where changing the setting quickly meant that the previous `refreshWorkspaceDefinitionCache` hadn't finished, leading to multiple progress bars. I updated the cancellation token code to resolve this.


---

## Worked Examples

I'm adding an example of the problem, and how this PR fixes it.

This data is common to all examples.

Lucee Mappings:
- /company => cfcs

ColdFusion:

```CFML
<!--- We want these references to work with "Go to Definition" --->
<cfset createObject("company.foo")>
<cfset createObject("home.page")>
```

### Example 1 - web root equals workspace root:

Everything works fine when the top level of the repo is the web root.

```
# Workspace layout
my-repo/
  + Application.cfc
  + cfcs/
    + foo.cfc
  + home/
    + page.cfc
  + ... (+10 folders)
```

Lucee uses `my-repo/` as the web root.


CFMLEditor Settings:

```jsonc
// These match the settings in Lucee.
"cfml.mappings": [
  {
    "logicalPath": "/company",
    "directoryPath": "cfcs",
    "isPhysicalDirectoryPath": false
  }
],
```

### Example 2 - web root is subfolder of workspace root:

When the web root is a subfolder, each child folder of the web root needs a separate mapping to work.

```
# Workspace layout
my-repo/
  + www
    + Application.cfc
    + cfcs/
      + foo.cfc
    + home/
      + page.cfc
    + ... (+10 folders)
```

Lucee uses `my-repo/www/` as the web root.

CFMLEditor Settings:
```jsonc
// the mappings don't match the Lucee config, and are harder to get right
"cfml.mappings": [
  {
    "logicalPath": "/company",
    "directoryPath": "src/cfcs",
    "isPhysicalDirectoryPath": false
  },
  {
    "logicalPath": "/home",
    "directoryPath": "src/home",
    "isPhysicalDirectoryPath": false
  },
  { /* ... +10 mappings for the other folders */ }
],
```

### Example 3 - web root is subfolder of workspace root (with custom web root setting):

The `webRoot` setting means the mappings can match the Lucee config.

```
# Workspace layout
my-repo/
  + www
    + Application.cfc
    + cfcs/
      + foo.cfc
    + home/
      + page.cfc
    + ... (+10 folders)
```

Lucee uses `my-repo/www/` as the web root.

CFMLEditor Settings:
```jsonc
// The webRoot setting allows the mappings to match the Lucee config
"cfml.webRoot": "www",
"cfml.mappings": [
  {
    "logicalPath": "/company",
    "directoryPath": "cfcs",
    "isPhysicalDirectoryPath": false
  }
],
```

## Screenshots
<img width="561" alt="image" src="https://github.com/user-attachments/assets/8b17fad2-6654-428a-870b-74e0cc000739" />
<img width="674" alt="image" src="https://github.com/user-attachments/assets/2b2af455-d86b-4b84-ad48-5fac152d7969" />
