### PR TITLE
96 copy package fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -544,6 +544,7 @@
 			},
 			{
 				"command": "cfml.copyPackage",
+				"category": "CFML",
 				"title": "Copy CFC Package Path"
 			}
 		],

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -1,7 +1,7 @@
 import { some } from "micromatch";
 import {
 	commands, ConfigurationChangeEvent, DocumentSelector, Extension, ExtensionContext, extensions,
-	FileSystemWatcher, IndentAction, LanguageConfiguration, languages, TextDocument, Uri, window, workspace, WorkspaceConfiguration, env,
+	FileSystemWatcher, IndentAction, LanguageConfiguration, languages, TextDocument, Uri, window, workspace, WorkspaceConfiguration,
 } from "vscode";
 import { COMPONENT_FILE_GLOB } from "./entities/component";
 import { Scope } from "./entities/scope";
@@ -9,7 +9,7 @@ import { decreasingIndentingTags, goToMatchingTag, nonIndentingTags } from "./en
 import { parseVariableAssignments, Variable } from "./entities/variable";
 import { cacheComponentFromDocument, setApplicationVariables, clearCachedComponent, removeApplicationVariables } from "./features/cachedEntities";
 import CFMLDocumentColorProvider from "./features/colorProvider";
-import { foldAllFunctions, showApplicationDocument, refreshGlobalDefinitionCache, refreshWorkspaceDefinitionCache, insertSnippet } from "./features/commands";
+import { foldAllFunctions, showApplicationDocument, refreshGlobalDefinitionCache, refreshWorkspaceDefinitionCache, insertSnippet, copyPackage } from "./features/commands";
 import { CommentType, toggleComment } from "./features/comment";
 import CFMLCompletionItemProvider from "./features/completionItemProvider";
 import CFMLDefinitionProvider from "./features/definitionProvider";
@@ -26,7 +26,6 @@ import { DocumentStateContext, getDocumentStateContext } from "./utils/documentU
 import { handleContentChanges } from "./features/autoclose";
 import { resolveBaseName, uriBaseName } from "./utils/fileUtil";
 // import { CFMLFlatPackageProvider } from "./views/components";
-import { convertPathToPackageName } from "./utils/cfcPackages";
 
 export const LANGUAGE_ID: string = "cfml";
 export const LANGUAGE_CFS_ID: string = "cfs";
@@ -142,6 +141,7 @@ export async function activate(context: ExtensionContext): Promise<api> {
 
 	context.subscriptions.push(commands.registerCommand("cfml.refreshGlobalDefinitionCache", refreshGlobalDefinitionCache));
 	context.subscriptions.push(commands.registerCommand("cfml.refreshWorkspaceDefinitionCache", refreshWorkspaceDefinitionCache));
+	context.subscriptions.push(commands.registerCommand("cfml.copyPackage", copyPackage));
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleLineComment", toggleComment(CommentType.Line, undefined)));
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.insertSnippet", insertSnippet));
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleBlockComment", toggleComment(CommentType.Block, undefined)));
@@ -273,28 +273,6 @@ export async function activate(context: ExtensionContext): Promise<api> {
 	// 		console.error("Failed to create ComponentTreeDataProvider:", error);
 	// 	}
 	// }
-
-	context.subscriptions.push(
-		commands.registerCommand(
-			"cfml.copyPackage",
-			(selectedFileUri: Uri) => {
-				const workspaceFolder = workspace.getWorkspaceFolder(selectedFileUri);
-				const workspacePath = workspaceFolder?.uri;
-				// We are not in a workspace or the file is not in a workspace
-				if (!workspacePath) {
-					return;
-				}
-				const mappings = workspace.getConfiguration("cfml").get("mappings", []);
-
-				const packagePath = convertPathToPackageName(
-					selectedFileUri,
-					mappings
-				);
-
-				env.clipboard.writeText(packagePath);
-			}
-		)
-	);
 
 	return api;
 }

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, Position, Range, TextDocument, Uri } from "vscode";
+import { CancellationToken, Position, Range, TextDocument, Uri, workspace } from "vscode";
 import { getComponent, hasComponent, cachedComponentPathToUri } from "../features/cachedEntities";
 import { MySet } from "../utils/collections";
 import { isCfcFile } from "../utils/contextUtil";
@@ -562,6 +562,27 @@ export function getServerUri(baseUri: Uri, _token: CancellationToken | undefined
 	// TODO: custom mapping
 
 	return componentUri;
+}
+
+/**
+ * Get the web root URI for a given file URI
+ *
+ * This is similar to `workspace.getWorkspaceFolder`, but it accounts for the `webRoot` setting.
+ * @param fileUri The URI of the file for which to get the web root
+ * @returns The web root URI for the given file URI, or undefined if the file is not in a workspace
+ */
+export function getWebRoot(fileUri: Uri): Uri | undefined {
+	// Get the workspace folder for the file URI, or return undefined if not found
+	const workspaceUri = workspace.getWorkspaceFolder(fileUri)?.uri;
+	if (!workspaceUri) {
+		return undefined;
+	}
+
+	// Add on the webRoot setting, which is relative to the workspace root
+	const webRootRelative = workspace.getConfiguration("cfml", fileUri).get<string>("webRoot", "");
+	const webrootUri = Uri.joinPath(workspaceUri, webRootRelative);
+
+	return webrootUri;
 }
 
 /**

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -132,7 +132,16 @@ export function insertSnippet(editor: TextEditor, edit: TextEditorEdit, args: Sn
  * Example: `/com/example/MyComponent.cfc` would be copied as `com.example.MyComponent`
  * @param selectedFileUri The URI of the file for which to copy the package path
  */
-export function copyPackage(selectedFileUri: Uri) {
+export function copyPackage(selectedFileUri?: Uri) {
+	// When run from the command palette, no file is passed, so use whatever is currently active.
+	if (!selectedFileUri) {
+		if (!window.activeTextEditor) {
+			window.showErrorMessage("No active text editor found.");
+			return;
+		}
+		selectedFileUri = window.activeTextEditor.document.uri;
+	}
+
 	const workspaceFolder = workspace.getWorkspaceFolder(selectedFileUri);
 	const workspacePath = workspaceFolder?.uri;
 	// We are not in a workspace or the file is not in a workspace

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -142,6 +142,12 @@ export function copyPackage(selectedFileUri?: Uri) {
 		selectedFileUri = window.activeTextEditor.document.uri;
 	}
 
+	// Avoid confusion when used with .cfm files by mistake
+	if (!selectedFileUri.path.toLowerCase().endsWith(".cfc")) {
+		window.showErrorMessage("Copy CFC Package Path only works for CFC files.");
+		return;
+	}
+
 	const workspaceFolder = workspace.getWorkspaceFolder(selectedFileUri);
 	const workspacePath = workspaceFolder?.uri;
 	// We are not in a workspace or the file is not in a workspace

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,5 +1,5 @@
 import { commands, TextDocument, Uri, window, workspace, WorkspaceConfiguration, TextEditor, CancellationToken, TextEditorEdit, Position, CancellationTokenSource, env } from "vscode";
-import { Component, getApplicationUri } from "../entities/component";
+import { Component, getApplicationUri, getWebRoot } from "../entities/component";
 import { UserFunction } from "../entities/userFunction";
 import CFDocsService from "../utils/cfdocs/cfDocsService";
 import { isCfcFile } from "../utils/contextUtil";
@@ -148,16 +148,18 @@ export function copyPackage(selectedFileUri?: Uri) {
 		return;
 	}
 
-	const workspaceFolder = workspace.getWorkspaceFolder(selectedFileUri);
-	const workspacePath = workspaceFolder?.uri;
-	// We are not in a workspace or the file is not in a workspace
-	if (!workspacePath) {
+	// Require a workspace so we have a web root to make the package path relative to (otherwise the absolute path would be used)
+	const webRootUri = getWebRoot(selectedFileUri);
+	if (!webRootUri) {
+		window.showErrorMessage("No workspace folder found for the selected file.");
 		return;
 	}
-	const mappings = workspace.getConfiguration("cfml").get("mappings", []);
+
+	const mappings = workspace.getConfiguration("cfml", selectedFileUri).get("mappings", []);
 
 	const packagePath = convertPathToPackageName(
 		selectedFileUri,
+		webRootUri,
 		mappings
 	);
 

--- a/src/test/cfcPackages.test.ts
+++ b/src/test/cfcPackages.test.ts
@@ -1,0 +1,49 @@
+import * as assert from "assert/strict";
+import { Uri } from "vscode";
+
+/**
+ * NOTE: This `convertPathToPackageName` doesn't run in the context of the active extension,
+ *       and cannot use the workspace API.
+ */
+import { convertPathToPackageName } from "../utils/cfcPackages";
+
+describe("convertPathToPackageName", function () {
+	it("should convert path relative to workspace folder", function () {
+		const packageName = convertPathToPackageName(
+			Uri.parse("/Users/foo.bar/example/src/components/MyComponent.cfc"),
+			Uri.parse("/Users/foo.bar/example"),
+			[]
+		);
+		assert.strictEqual(packageName, "src.components.MyComponent");
+	});
+	it("should convert path relative to mapping", function () {
+		const packageName = convertPathToPackageName(
+			Uri.parse("/Users/foo.bar/example/src/components/MyComponent.cfc"),
+			Uri.parse("/Users/foo.bar/example"),
+			[
+				{ logicalPath: "/com", directoryPath: "src/components", isPhysicalDirectoryPath: false },
+			]
+		);
+		assert.strictEqual(packageName, "com.MyComponent");
+	});
+	it("should convert path relative to mapping and webRoot", function () {
+		const packageName = convertPathToPackageName(
+			Uri.parse("/Users/foo.bar/example/src/components/MyComponent.cfc"),
+			Uri.parse("/Users/foo.bar/example/src"),
+			[
+				{ logicalPath: "/com", directoryPath: "components", isPhysicalDirectoryPath: false },
+			]
+		);
+		assert.strictEqual(packageName, "com.MyComponent");
+	});
+	it("should convert path relative to physical mapping", function () {
+		const packageName = convertPathToPackageName(
+			Uri.parse("/Users/foo.bar/example/src/components/MyComponent.cfc"),
+			Uri.parse("/Users/foo.bar/example"),
+			[
+				{ logicalPath: "/com", directoryPath: "/Users/foo.bar/example/src/components", isPhysicalDirectoryPath: true },
+			]
+		);
+		assert.strictEqual(packageName, "com.MyComponent");
+	});
+});

--- a/src/utils/cfcPackages.ts
+++ b/src/utils/cfcPackages.ts
@@ -26,7 +26,7 @@ export function convertPathToPackageName(
 		return b.directoryPath.length - a.directoryPath.length;
 	});
 
-	relPath = workspace.asRelativePath(path);
+	relPath = workspace.asRelativePath(path, false);
 
 	for (const mapping of mappings) {
 		if (mapping.isPhysicalDirectoryPath

--- a/src/utils/cfcPackages.ts
+++ b/src/utils/cfcPackages.ts
@@ -1,8 +1,8 @@
 // This file provides functions to convert paths to package names and vice versa,
 // It also allows replacement of packagenames with mappings.
 
-import { join } from "path";
-import { Uri, workspace } from "vscode";
+import { join, relative } from "path";
+import { Uri } from "vscode";
 
 export interface CFMLMapping {
 	directoryPath: string; // The physical path to the directory
@@ -10,13 +10,21 @@ export interface CFMLMapping {
 	isPhysicalDirectoryPath: boolean; // Whether the directoryPath is a physical path
 }
 /**
+ * Get the package name for a given file path based on the provided mappings and web root.
  *
- * @param path
- * @param mappings
+ * Example:
+ *
+ *     convertPathToPackageName(
+ *         "/Users/foo.bar/example/src/components/MyComponent.cfc", ...
+ *     ) => "com.MyComponent"
+ * @param path The CFC file path for which to convert to a package name
+ * @param webRoot The web root URI, which the package name will be relative to
+ * @param mappings An array of CFMLMapping objects that define the logical and physical paths
  * @returns
  */
 export function convertPathToPackageName(
 	path: Uri,
+	webRoot: Uri,
 	mappings: CFMLMapping[]
 ): string {
 	let relPath = "";
@@ -26,7 +34,7 @@ export function convertPathToPackageName(
 		return b.directoryPath.length - a.directoryPath.length;
 	});
 
-	relPath = workspace.asRelativePath(path, false);
+	relPath = relative(webRoot.path, path.path);
 
 	for (const mapping of mappings) {
 		if (mapping.isPhysicalDirectoryPath


### PR DESCRIPTION
- Refactor the `copyPackage` command to match the other commands
  - Move `copyPackage` command to `commands.ts`
  - Put `registerCommand("cfml.copyPackage"...)` with the other `registerCommand` lines
  - Show with "CFML: " prefix in the Command Palette
- Fix incorrect package name when there are multiple workspace folders
- Make the package name take into account the new `cfml.webRoot` setting
- Use the active editor when run from the Command Palette
- Show error messages when the command cannot complete

---

It may be useful to review each commit separately. I've taken care to focus on one thing in each commit.