### PR TITLE
Rename webRoot to webroot

### DIFF
--- a/package.json
+++ b/package.json
@@ -480,10 +480,10 @@
 							"directoryPath"
 						]
 					},
-					"markdownDescription": "Represents CFML mappings from logicalPath to directoryPath.\n\nIf paths are relative to a subfolder instead of the workspace root, see `#cfml.webRoot#`.",
+					"markdownDescription": "Represents CFML mappings from logicalPath to directoryPath.\n\nIf paths are relative to a subfolder instead of the workspace root, see `#cfml.webroot#`.",
 					"scope": "resource"
 				},
-				"cfml.webRoot": {
+				"cfml.webroot": {
 					"type": "string",
 					"default": "",
 					"markdownDescription": "A subfolder used as the web root by the ColdFusion/Lucee server.\n\nTypically this will be blank, or a subfolder like `public`, `www`, `src`, or wherever the main `Application.cfc` is located.\n\nUse in conjunction with `#cfml.mappings#` to resolve component paths.",

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -243,7 +243,7 @@ export async function activate(context: ExtensionContext): Promise<api> {
 		if (evt.affectsConfiguration("cfml.globalDefinitions") || evt.affectsConfiguration("cfml.cfDocs") || evt.affectsConfiguration("cfml.engine")) {
 			commands.executeCommand("cfml.refreshGlobalDefinitionCache");
 		}
-		if (evt.affectsConfiguration("cfml.mappings") || evt.affectsConfiguration("cfml.webRoot")) {
+		if (evt.affectsConfiguration("cfml.mappings") || evt.affectsConfiguration("cfml.webroot")) {
 			// Refresh cached components so the config changes take effect
 			commands.executeCommand("cfml.refreshWorkspaceDefinitionCache");
 		}

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -567,20 +567,20 @@ export function getServerUri(baseUri: Uri, _token: CancellationToken | undefined
 /**
  * Get the web root URI for a given file URI
  *
- * This is similar to `workspace.getWorkspaceFolder`, but it accounts for the `webRoot` setting.
+ * This is similar to `workspace.getWorkspaceFolder`, but it accounts for the `webroot` setting.
  * @param fileUri The URI of the file for which to get the web root
  * @returns The web root URI for the given file URI, or undefined if the file is not in a workspace
  */
-export function getWebRoot(fileUri: Uri): Uri | undefined {
+export function getWebroot(fileUri: Uri): Uri | undefined {
 	// Get the workspace folder for the file URI, or return undefined if not found
 	const workspaceUri = workspace.getWorkspaceFolder(fileUri)?.uri;
 	if (!workspaceUri) {
 		return undefined;
 	}
 
-	// Add on the webRoot setting, which is relative to the workspace root
-	const webRootRelative = workspace.getConfiguration("cfml", fileUri).get<string>("webRoot", "");
-	const webrootUri = Uri.joinPath(workspaceUri, webRootRelative);
+	// Add on the webroot setting, which is relative to the workspace root
+	const webrootRelative = workspace.getConfiguration("cfml", fileUri).get<string>("webroot", "");
+	const webrootUri = Uri.joinPath(workspaceUri, webrootRelative);
 
 	return webrootUri;
 }

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -1,5 +1,5 @@
 import { commands, TextDocument, Uri, window, workspace, WorkspaceConfiguration, TextEditor, CancellationToken, TextEditorEdit, Position, CancellationTokenSource, env } from "vscode";
-import { Component, getApplicationUri, getWebRoot } from "../entities/component";
+import { Component, getApplicationUri, getWebroot } from "../entities/component";
 import { UserFunction } from "../entities/userFunction";
 import CFDocsService from "../utils/cfdocs/cfDocsService";
 import { isCfcFile } from "../utils/contextUtil";
@@ -149,8 +149,8 @@ export function copyPackage(selectedFileUri?: Uri) {
 	}
 
 	// Require a workspace so we have a web root to make the package path relative to (otherwise the absolute path would be used)
-	const webRootUri = getWebRoot(selectedFileUri);
-	if (!webRootUri) {
+	const webrootUri = getWebroot(selectedFileUri);
+	if (!webrootUri) {
 		window.showErrorMessage("No workspace folder found for the selected file.");
 		return;
 	}
@@ -159,7 +159,7 @@ export function copyPackage(selectedFileUri?: Uri) {
 
 	const packagePath = convertPathToPackageName(
 		selectedFileUri,
-		webRootUri,
+		webrootUri,
 		mappings
 	);
 

--- a/src/test/cfcPackages.test.ts
+++ b/src/test/cfcPackages.test.ts
@@ -26,7 +26,7 @@ describe("convertPathToPackageName", function () {
 		);
 		assert.strictEqual(packageName, "com.MyComponent");
 	});
-	it("should convert path relative to mapping and webRoot", function () {
+	it("should convert path relative to mapping and webroot", function () {
 		const packageName = convertPathToPackageName(
 			Uri.parse("/Users/foo.bar/example/src/components/MyComponent.cfc"),
 			Uri.parse("/Users/foo.bar/example/src"),

--- a/src/utils/cfcPackages.ts
+++ b/src/utils/cfcPackages.ts
@@ -18,13 +18,13 @@ export interface CFMLMapping {
  *         "/Users/foo.bar/example/src/components/MyComponent.cfc", ...
  *     ) => "com.MyComponent"
  * @param path The CFC file path for which to convert to a package name
- * @param webRoot The web root URI, which the package name will be relative to
+ * @param webroot The web root URI, which the package name will be relative to
  * @param mappings An array of CFMLMapping objects that define the logical and physical paths
  * @returns
  */
 export function convertPathToPackageName(
 	path: Uri,
-	webRoot: Uri,
+	webroot: Uri,
 	mappings: CFMLMapping[]
 ): string {
 	let relPath = "";
@@ -34,7 +34,7 @@ export function convertPathToPackageName(
 		return b.directoryPath.length - a.directoryPath.length;
 	});
 
-	relPath = relative(webRoot.path, path.path);
+	relPath = relative(webroot.path, path.path);
 
 	for (const mapping of mappings) {
 		if (mapping.isPhysicalDirectoryPath

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -200,9 +200,9 @@ export function resolveRootPath(baseUri: Uri, appendingPath: string): string | u
 
 	// Include the webroot (relative to the workspace root)
 	// Used when the application is served from a subdirectory ("public", "www", "src", etc...)
-	const webRoot = workspace.getConfiguration("cfml", baseUri).get<string>("webRoot", "");
+	const webroot = workspace.getConfiguration("cfml", baseUri).get<string>("webroot", "");
 
-	return Uri.joinPath(root.uri, webRoot, appendingPath).fsPath;
+	return Uri.joinPath(root.uri, webroot, appendingPath).fsPath;
 }
 
 /**


### PR DESCRIPTION
I picked `webRoot`, but now realise `webroot` (all lowercase) is more common.

For example, in the Lucee code `webroot` appears 77 times, and `webRoot` appears 0 times.

The `cfml.webroot` setting has not been released yet, so it's not too late to change this.