### PR TITLE
Do not remove unreachable code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,8 @@
 	],
 	"editor.formatOnSave": false,
 	"editor.codeActionsOnSave": {
-		"source.fixAll": "explicit"
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll.ts": "never",
 	},
 	"eslint.rules.customizations": [
 		{


### PR DESCRIPTION
The setting `editor.codeActionsOnSave` => `source.fixAll.ts` will delete all unreachable code. This can happen after saving a file with a syntax error, or using a `return` statement for debugging.

Here's an old ticket about this problem: https://github.com/microsoft/vscode/issues/109530. The ticket is closed with "as-designed".

I'm disabling ALL `ts` auto-fixes. I have no idea what others are available. I looked but I couldn't find a list. The `ts` errors will still be highlighted and quick-fixes can be applied manually.

Literally no one ever wanted their code to be deleted on save. The VSCode team are wrong to treat it as anything other than a bug. It's far too likely to result in code being deleted unintentionally and unnoticed, and then committed.

## Example

```ts
// src/cfmlMain.ts
export async function activate(context: ExtensionContext): Promise<api> {
	return; // Everything after this is deleted on save
        // Clearly your intention was to delete all this
	extensionContext = context;
        ...
	return api;
}
```

## Alternatives
There is no other way to disable this other than to disable the unreachable-code rule:
```jsonc
// tsconfig.json
{
	"compilerOptions": {
		"allowUnreachableCode": true
	},
}
```

This is a bad solution, as we WANT unreachable code to be highlighted as an error. We just don't want it deleted automatically.

## Notes

It's not necessary to add `"source.fixAll.ts" : "never"`. This was done to make anyone who wants to turn it on think twice about doing so.