### PR TITLE
103 cfscript comment ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
 				"eslint": "^9.30.1",
 				"eslint-plugin-jsdoc": "^51.3.2",
 				"rimraf": "^6.0.1",
+				"string-dedent": "^3.0.2",
 				"ts-loader": "^9.5.2",
 				"tsx": "^4.20.3",
 				"typescript": "^5.8.3"
@@ -9638,6 +9639,16 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"license": "MIT"
+		},
+		"node_modules/string-dedent": {
+			"version": "3.0.2",
+			"resolved": "http://nexus.aws.axcelerate.com.au:8081/repository/ax_npm_group/string-dedent/-/string-dedent-3.0.2.tgz",
+			"integrity": "sha512-M4q+HpHCtGXlbyzYDOcOo7V185dlq6YXvGUPcWZqL4vttCX9gFYoWIOxcPd7v5CAYcTJsGLs3ZJCAH2TXONF/g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -648,7 +648,6 @@
 		"vscode-uri": "^3.1.0"
 	},
 	"devDependencies": {
-		"browserify": "^17.0.1",
 		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
 		"@eslint/eslintrc": "^3.3.1",
 		"@eslint/js": "^9.20.0",
@@ -665,11 +664,13 @@
 		"@vscode/test-electron": "^2.5.2",
 		"@vscode/test-web": "^0.0.71",
 		"@vscode/vsce": "^3.6.0",
+		"browserify": "^17.0.1",
 		"esbuild": "^0.25.5",
 		"esbuild-plugin-tsc": "^0.5.0",
 		"eslint": "^9.30.1",
 		"eslint-plugin-jsdoc": "^51.3.2",
 		"rimraf": "^6.0.1",
+		"string-dedent": "^3.0.2",
 		"ts-loader": "^9.5.2",
 		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"

--- a/src/test/contextUtil.test.ts
+++ b/src/test/contextUtil.test.ts
@@ -1,0 +1,165 @@
+import { Uri, Range } from "vscode";
+import { assertRangeArrayEqual } from "./testAssertions";
+import { getDocumentContextRanges } from "../utils/contextUtil";
+import { LSTextDocument } from "../utils/LSTextDocument";
+import dedent from "string-dedent";
+
+describe("getDocumentContextRanges", function () {
+	describe("accurate", function () {
+		generateTests_getDocumentContextRanges(false);
+	});
+	describe("fast", function () {
+		generateTests_getDocumentContextRanges(true);
+	});
+});
+
+function generateTests_getDocumentContextRanges(fast: boolean) {
+	const isScript = true;
+	const token = undefined;
+	const docRange = undefined;
+	const exclDocumentRanges = undefined;
+	it("should parse single-line comment", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		// Foo
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 0, 6),
+		]);
+	});
+
+	it("should parse adjacent single-line comments separately", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		// Foo
+		// Floop
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 0, 6),
+			new Range(1, 0, 1, 8),
+		]);
+	});
+
+	it("should parse line comment on last line (no trailing newline)", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		a = 1;
+		// Foo
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(1, 0, 1, 6),
+		]);
+	});
+
+	it("should parse line comment on last line (with trailing newline)", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		a = 1;
+		// Foo
+
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(1, 0, 1, 6),
+		]);
+	});
+
+	it("should parse single-line comment block", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		/* foo */
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 0, 9),
+		]);
+	});
+
+	it("should parse single-line comment block on last line", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		a = 1;
+		/* foo */
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(1, 0, 1, 9),
+		]);
+	});
+
+	it("should parse multi-line comment", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		/*
+		foo
+		*/
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 2, 2),
+		]);
+	});
+
+	it("should parse multi-line comment on last", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		a = 1;
+		/*
+		foo
+		*/
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(1, 0, 3, 2),
+		]);
+	});
+
+	it("should ignore single-line comment in comment block", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		/*
+		// foo
+		*/
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 2, 2),
+		]);
+	});
+
+	it("should ignore multi-line comment start in existing comment", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		/*
+		/* foo
+		*/
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 2, 2),
+		]);
+	});
+
+	it("should parse docblock comment", function () {
+		const doc = new LSTextDocument(Uri.parse("untitled"), "cfml", 1, dedent`
+		/**
+		 * Foo
+		 */
+		a = 1;
+		`);
+		const contextRanges = getDocumentContextRanges(doc, isScript, docRange, fast, token, exclDocumentRanges);
+		const comments = contextRanges.commentRanges;
+		assertRangeArrayEqual(comments, [
+			new Range(0, 0, 2, 3),
+		]);
+	});
+}

--- a/src/test/testAssertions.ts
+++ b/src/test/testAssertions.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert/strict";
 import { DefinitionLink, Range, workspace } from "vscode";
+import { rangeToString } from "./testUtils";
 
 /**
  * Assert that the target of a DefinitionLink matches a given text string and surrounding context
@@ -40,4 +41,22 @@ export async function assertDefinitionLinkTarget(definition: DefinitionLink, exp
 
 	const actual = `${actualBefore}${cursor}${actualValue}${cursor}${actualAfter}`;
 	assert.strictEqual(actual, expected);
+}
+
+/**
+ * Asserts that two Range objects are equal by comparing their string representations.
+ * @param actual The actual Range object to compare.
+ * @param expected The expected Range object to compare against.
+ */
+export function assertRangeEqual(actual: Range, expected: Range) {
+	assert.strictEqual(rangeToString(actual), rangeToString(expected), `Expected range ${rangeToString(expected)} but got ${rangeToString(actual)}`);
+}
+
+/**
+ * Asserts that two arrays of Range objects are equal by comparing their string representations.
+ * @param actual The actual array of Range objects to compare.
+ * @param expected The expected array of Range objects to compare against.
+ */
+export function assertRangeArrayEqual(actual: Range[], expected: Range[]) {
+	assert.deepEqual(actual.map(rangeToString), expected.map(rangeToString), `Expected ranges do not match.`);
 }

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -1,5 +1,5 @@
 import assert from "assert/strict";
-import { TextDocument, Position, commands, DefinitionLink } from "vscode";
+import { TextDocument, Position, commands, DefinitionLink, Range } from "vscode";
 
 /**
  * Get a position in the document based on a search text and a cursor
@@ -64,3 +64,16 @@ export async function findDefinition(doc: TextDocument, search: string, cursor: 
 	assert.strictEqual(definitions.length, matches, "Expected exactly one definition");
 	return definitions[posn];
 }
+
+/**
+ * Converts a Range object to a string representation.
+ *
+ * Math notation: square brackets [ ] mean inclusive, parentheses ( ) mean exclusive.
+ *
+ * For example, the "Foo" in "FooBar" is represented as "[0:0 -> 0:3)". Character 0 "F" is included, and character 3 "B" is excluded.
+ * @param range The range to convert to a string
+ * @returns A string representation of the range in the format "[startLine:startCharacter -> endLine:endCharacter)"
+ */
+export function rangeToString(range: Range): string {
+	return `[${range.start.line}:${range.start.character} -> ${range.end.line}:${range.end.character})`;
+};

--- a/src/utils/contextUtil.ts
+++ b/src/utils/contextUtil.ts
@@ -503,6 +503,11 @@ function getCommentAndStringRangesIterated(document: TextDocument, isScript: boo
 					}
 				}
 			}
+			// Handle the edge case of a line comment on the last line of the document
+			else if (previousPosition && commentContext.start && commentContext.commentType === CommentType.Line && offset === textOffsetEnd - 1) {
+				const rangeLengthFix = characterAtPosition === "\n" ? 0 : 1; // If the last character is a newline, don't include it in the range
+				commentRanges.push(new Range(commentContext.start, position.translate(0, rangeLengthFix)));
+			}
 		}
 		else if (stringContext.inString) {
 			if (characterAtPosition === stringEmbeddedCFMLDelimiter) {


### PR DESCRIPTION
- Add unit tests for comment range parsing
- Added new range assertions for more readable error messages
- Added string-dedent NPM devDependency (it has 0 dependencies of its own)

Fixed these examples not being parsed (both had empty ranges):

```
a = 1;
// Foo (no newline)
```

```
a = 1;
// Foo (has newline)

```

I don't know if we actually do anything with these, so it may be irrelevant.