### PR TITLE
72 show minimum version on inline help

### DIFF
--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -1,5 +1,5 @@
 import { CancellationToken, Hover, HoverProvider, MarkdownString, Position, Range, TextDocument, TextLine, Uri, workspace, WorkspaceConfiguration } from "vscode";
-import { extensionContext, LANGUAGE_ID } from "../cfmlMain";
+import { LANGUAGE_ID } from "../cfmlMain";
 import { VALUE_PATTERN } from "../entities/attribute";
 import { Component, COMPONENT_EXT, objectNewInstanceInitPrefix } from "../entities/component";
 import { IPropertyData, IAtDirectiveData } from "../entities/css/cssLanguageTypes";
@@ -489,8 +489,8 @@ export default class CFMLHoverProvider implements HoverProvider {
 	 * @returns
 	 */
 	public createHoverText(definition: HoverProviderItem): MarkdownString[] | undefined {
-		const cfdocsIconUri: Uri = Uri.joinPath(extensionContext.extensionUri, "images/cfdocs.png");
-		const mdnIconUri: Uri = Uri.joinPath(extensionContext.extensionUri, "images/mdn.png");
+		const cfdocsIconUri: Uri = CFMLEngine.getIconUri("cfdocs");
+		const mdnIconUri: Uri = CFMLEngine.getIconUri("mdn");
 
 		const hoverTexts: MarkdownString[] = [];
 		let syntax: string = definition.syntax;

--- a/src/utils/cfdocs/cfmlEngine.ts
+++ b/src/utils/cfdocs/cfmlEngine.ts
@@ -1,5 +1,4 @@
-import { valid, eq, lt, lte, gt, gte, clean } from "semver";
-import { DataType } from "../../entities/dataType";
+import { valid, eq, lt, lte, gt, gte, clean, coerce } from "semver";
 import { Uri } from "vscode";
 import { extensionContext } from "../../cfmlMain";
 
@@ -178,18 +177,7 @@ export class CFMLEngine {
 		if (versionStr !== "" && clean(versionStr, true)) {
 			return clean(versionStr, true) || undefined;
 		}
-		else if (DataType.isNumeric(versionStr)) {
-			const splitVer: string[] = versionStr.split(".");
-			while (splitVer.length < 3) {
-				splitVer.push("0");
-			}
-			const reconstructedVer = splitVer.join(".");
-			if (valid(reconstructedVer, true)) {
-				return valid(reconstructedVer, true) || undefined;
-			}
-		}
-
-		return undefined;
+		return valid(coerce(versionStr)) || undefined;
 	}
 
 	/**

--- a/src/utils/cfdocs/cfmlEngine.ts
+++ b/src/utils/cfdocs/cfmlEngine.ts
@@ -185,7 +185,7 @@ export class CFMLEngine {
 	 * @param name CFMLEngineName
 	 * @returns
 	 */
-	public static getIconUri(name: CFMLEngineName): Uri {
+	public static getIconUri(name: CFMLEngineName | "cfdocs" | "mdn"): Uri {
 		return Uri.joinPath(extensionContext.extensionUri, `images/${name}.png`);
 	}
 }

--- a/src/utils/cfdocs/definitionInfo.ts
+++ b/src/utils/cfdocs/definitionInfo.ts
@@ -316,8 +316,19 @@ export class CFDocsDefinitionInfo {
 
 		// We want to check if this definition is compatible with the user's chosen CFML engine.
 		// If this definition does not specify any engines, assume it is compatible with all engines.
-		if (targetEngineVendor === CFMLEngineName.Unknown || !this.engines) {
+		if (!this.engines) {
 			return true;
+		}
+
+		// If the user hasn't specified an engine, we can assume that most definitions are compatible.
+		if (targetEngineVendor === CFMLEngineName.Unknown) {
+			// Get the set of engines supported by this definition.
+			const engineSet = new Set(Object.keys(this.engines));
+			// CFDocs provides compatibility info for some non-CFML engines, like BoxLang.
+			// Any definitions that are not compatible with a CFML engine should not be shown.
+			engineSet.delete("boxlang");
+			const hasCompatibleEngine = engineSet.size > 0;
+			return hasCompatibleEngine;
 		}
 
 		const vendorCompatibility: EngineCompatibilityDetail = this.engines[targetEngineVendor];

--- a/src/utils/cfdocs/definitionInfo.ts
+++ b/src/utils/cfdocs/definitionInfo.ts
@@ -308,39 +308,47 @@ export class CFDocsDefinitionInfo {
 
 	/**
 	 * Checks if this definition is compatible with given engine
-	 * @param engine The CFML engine with which to check compatibility
+	 * @param targetEngine The CFML engine with which to check compatibility
 	 * @returns
 	 */
-	public isCompatible(engine: CFMLEngine): boolean {
-		const engineVendor: CFMLEngineName = engine.getName();
-		if (engineVendor === CFMLEngineName.Unknown || !this.engines) {
+	public isCompatible(targetEngine: CFMLEngine): boolean {
+		const targetEngineVendor: CFMLEngineName = targetEngine.getName();
+
+		// We want to check if this definition is compatible with the user's chosen CFML engine.
+		// If this definition does not specify any engines, assume it is compatible with all engines.
+		if (targetEngineVendor === CFMLEngineName.Unknown || !this.engines) {
 			return true;
 		}
 
-		const engineCompat: EngineCompatibilityDetail = this.engines[engineVendor];
-		if (!engineCompat) {
+		const vendorCompatibility: EngineCompatibilityDetail = this.engines[targetEngineVendor];
+		if (!vendorCompatibility) {
+			// Example: CFDocs has info for `arrayGetMetadata()`, but Lucee is not listed as a compatible engine (at least when this was written)
 			return false;
 		}
 
-		const engineVersion: string | undefined = engine.getVersion();
-		if (!engineVersion) {
+		const targetEngineVersion: string | undefined = targetEngine.getVersion();
+		if (!targetEngineVersion) {
+			// This definition may have a min or max version, but if the user hasn't specified an engine version, assume it is compatible.
 			return true;
 		}
 
-		if (engineCompat.minimum_version) {
-			const minEngine: CFMLEngine = new CFMLEngine(engineVendor, engineCompat.minimum_version);
-			if (engine.isOlder(minEngine)) {
+		if (vendorCompatibility.minimum_version) {
+			const earliestSupportedVersion: CFMLEngine = new CFMLEngine(targetEngineVendor, vendorCompatibility.minimum_version);
+			if (targetEngine.isOlder(earliestSupportedVersion)) {
+				// Example: `arraySplice()` has a minimum version of Lucee 6, or ColdFusion 2018.0.5
 				return false;
 			}
 		}
 
-		if (engineCompat.removed) {
-			const maxEngine: CFMLEngine = new CFMLEngine(engineVendor, engineCompat.removed);
-			if (engine.isNewerOrEquals(maxEngine)) {
+		if (vendorCompatibility.removed) {
+			const earliestUnsupportedEngine: CFMLEngine = new CFMLEngine(targetEngineVendor, vendorCompatibility.removed);
+			if (targetEngine.isNewerOrEquals(earliestUnsupportedEngine)) {
+				// Example: `GetBaseTemplatePath()` has been removed in ColdFusion 2025
 				return false;
 			}
 		}
 
+		// The definition is compatible with the user's engine and version
 		return true;
 	}
 


### PR DESCRIPTION
### What has changed?

The hover docs now show the minimum version for each engine.

<img width="391" height="164" alt="image" src="https://github.com/user-attachments/assets/6f36e37d-a3c3-4dde-a510-f33d64644865" />

### Why were the changes introduced?

To help developers using older Lucee versions.

### Anything Else/Other

The hover docs will convert the version to semver, e.g. a min version of `6.2.1.16` will be displayed as `6.2.1`. CFML Editor expects the minimum version field to use semver format, e.g. `1.2.3`. Lucee uses a variant with an extra component, e.g. `1.2.3.4`. CFDocs provide semver versions, but the Lucee documentation provide the variant.

Removed docs for functions that are only supported by BoxLang.