### PR TITLE
Fixes for cfscript range calculation / use for comments

### DIFF
--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -51,6 +51,7 @@ const DOCUMENT_SELECTOR: DocumentSelector = [
 
 export let extensionContext: ExtensionContext;
 let bulkCaching: boolean = false;
+let currentConfigIsTag: boolean = false;
 
 export type api = {
 	isBulkCaching(): boolean;
@@ -248,6 +249,22 @@ export function setBulkCaching(value: boolean): void {
  */
 export function getBulkCaching(): boolean {
 	return bulkCaching;
+}
+
+/**
+ *
+ * @param value
+ */
+export function setCurrentConfigIsTag(value: boolean): void {
+	currentConfigIsTag = value;
+}
+
+/**
+ *
+ * @returns
+ */
+export function getCurrentConfigIsTag(): boolean {
+	return currentConfigIsTag;
 }
 
 /**

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -7,7 +7,7 @@ import { decreasingIndentingTags, goToMatchingTag, nonIndentingTags } from "./en
 import { cacheComponentFromDocument, clearCachedComponent, removeApplicationVariables, cacheComponentFromUri, cacheApplicationFromDocument } from "./features/cachedEntities";
 import CFMLDocumentColorProvider from "./features/colorProvider";
 import { foldAllFunctions, showApplicationDocument, refreshGlobalDefinitionCache, refreshWorkspaceDefinitionCache, insertSnippet, copyPackage, goToRouteController, goToRouteView } from "./features/commands";
-import { CommentType, toggleComment } from "./features/comment";
+import { cfmlCommentRules, CommentType, toggleComment } from "./features/comment";
 import CFMLCompletionItemProvider from "./features/completionItemProvider";
 import CFMLDefinitionProvider from "./features/definitionProvider";
 import DocBlockCompletions from "./features/docBlocker/docCompletionProvider";
@@ -75,6 +75,10 @@ export async function activate(context: ExtensionContext): Promise<api> {
 		indentationRules: {
 			increaseIndentPattern: new RegExp(`<(?!\\?|(?:${nonIndentingTags.join("|")})\\b|[^>]*\\/>)([-_.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}"']*$`, "i"),
 			decreaseIndentPattern: new RegExp(`^\\s*(<\\/[-_.A-Za-z0-9]+\\b[^>]*>|-?-->|\\}|<(${decreasingIndentingTags.join("|")})\\b[^>]*>)`, "i"),
+		},
+		comments: {
+			lineComment: cfmlCommentRules.scriptLineComment,
+			blockComment: cfmlCommentRules.scriptBlockComment,
 		},
 		onEnterRules: [
 			{

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -7,7 +7,7 @@ import { decreasingIndentingTags, goToMatchingTag, nonIndentingTags } from "./en
 import { cacheComponentFromDocument, clearCachedComponent, removeApplicationVariables, cacheComponentFromUri, cacheApplicationFromDocument } from "./features/cachedEntities";
 import CFMLDocumentColorProvider from "./features/colorProvider";
 import { foldAllFunctions, showApplicationDocument, refreshGlobalDefinitionCache, refreshWorkspaceDefinitionCache, insertSnippet, copyPackage, goToRouteController, goToRouteView } from "./features/commands";
-import { cfmlCommentRules, CommentType, toggleComment } from "./features/comment";
+import { cfmlCommentRules, toggleBlockComment, toggleLineComment } from "./features/comment";
 import CFMLCompletionItemProvider from "./features/completionItemProvider";
 import CFMLDefinitionProvider from "./features/definitionProvider";
 import DocBlockCompletions from "./features/docBlocker/docCompletionProvider";
@@ -118,9 +118,9 @@ export async function activate(context: ExtensionContext): Promise<api> {
 	context.subscriptions.push(commands.registerCommand("cfml.refreshGlobalDefinitionCache", refreshGlobalDefinitionCache));
 	context.subscriptions.push(commands.registerCommand("cfml.refreshWorkspaceDefinitionCache", refreshWorkspaceDefinitionCache));
 	context.subscriptions.push(commands.registerCommand("cfml.copyPackage", copyPackage));
-	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleLineComment", toggleComment(CommentType.Line, undefined)));
+	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleLineComment", toggleLineComment));
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.insertSnippet", insertSnippet));
-	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleBlockComment", toggleComment(CommentType.Block, undefined)));
+	context.subscriptions.push(commands.registerTextEditorCommand("cfml.toggleBlockComment", toggleBlockComment));
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.openActiveApplicationFile", showApplicationDocument));
 	context.subscriptions.push(commands.registerTextEditorCommand("cfml.goToMatchingTag", goToMatchingTag));

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -506,17 +506,6 @@ export function getTagPattern(tagName: string): RegExp {
 }
 
 /**
- * Returns a pattern that matches start and end tags with the given name, using an or `|` condition so they're matched independantly
- * and can be used for loops that match relevant start and end tags
- * @param tagName The name of the tag to capture
- * @returns
- */
-export function getTagStartAndEndPattern(tagName: string): RegExp {
-	// Attributes capture fails if an attribute value contains >
-	return new RegExp(`((?:<${tagName}\\b\\s*)(?:[^>]*?)(?:>)|(?:<\\/${tagName}>))`, "gi");
-}
-
-/**
  * Returns a pattern that matches start tags with the given name.
  * Capture groups:
  * 1. Prefix

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -506,6 +506,17 @@ export function getTagPattern(tagName: string): RegExp {
 }
 
 /**
+ * Returns a pattern that matches start and end tags with the given name, using an or `|` condition so they're matched independantly
+ * and can be used for loops that match relevant start and end tags
+ * @param tagName The name of the tag to capture
+ * @returns
+ */
+export function getTagStartAndEndPattern(tagName: string): RegExp {
+	// Attributes capture fails if an attribute value contains >
+	return new RegExp(`((?:<${tagName}\\b\\s*)(?:[^>]*?)(?:>)|(?:<\\/${tagName}>))`, "gi");
+}
+
+/**
  * Returns a pattern that matches start tags with the given name.
  * Capture groups:
  * 1. Prefix

--- a/src/features/comment.ts
+++ b/src/features/comment.ts
@@ -1,5 +1,5 @@
 import { Position, languages, commands, window, TextEditor, LanguageConfiguration, TextDocument, CharacterPair, CancellationToken, Range } from "vscode";
-import { LANGUAGE_ID } from "../cfmlMain";
+import { getCurrentConfigIsTag, LANGUAGE_ID, setCurrentConfigIsTag } from "../cfmlMain";
 import { isCfcFile, getTagCommentRanges, isCfsFile, getCfScriptRanges } from "../utils/contextUtil";
 import { getComponent, hasComponent } from "./cachedEntities";
 
@@ -83,19 +83,22 @@ export function toggleComment(commentType: CommentType, _token: CancellationToke
 		if (editor) {
 			// const isSingleLine: boolean = (editor.selections.every(selection => selection.isSingleLine) && editor.selections.length === 1);
 			const tagComment: boolean = isTagComment(editor.document, editor.selection.start, _token);
-			const languageConfig: LanguageConfiguration = tagComment
-				? {
-						comments: {
-							blockComment: cfmlCommentRules.tagBlockComment,
-						},
-					}
-				: {
-						comments: {
-							lineComment: cfmlCommentRules.scriptLineComment,
-							blockComment: cfmlCommentRules.scriptBlockComment,
-						},
-					};
-			languages.setLanguageConfiguration(LANGUAGE_ID, languageConfig);
+			if (getCurrentConfigIsTag() !== tagComment) {
+				setCurrentConfigIsTag(tagComment);
+				const languageConfig: LanguageConfiguration = tagComment
+					? {
+							comments: {
+								blockComment: cfmlCommentRules.tagBlockComment,
+							},
+						}
+					: {
+							comments: {
+								lineComment: cfmlCommentRules.scriptLineComment,
+								blockComment: cfmlCommentRules.scriptBlockComment,
+							},
+						};
+				languages.setLanguageConfiguration(LANGUAGE_ID, languageConfig);
+			}
 			const command: string = getCommentCommand(commentType);
 			commands.executeCommand(command);
 		}

--- a/src/features/comment.ts
+++ b/src/features/comment.ts
@@ -73,37 +73,59 @@ function getCommentCommand(commentType: CommentType): string {
 }
 
 /**
+ * @param editor
+ */
+export function toggleBlockComment(editor: TextEditor): void {
+	if (editor) {
+		const tagComment: boolean = isTagComment(editor.document, editor.selection.start, undefined);
+		toggleComment(CommentType.Block, editor, tagComment);
+	}
+	else {
+		window.showInformationMessage("No editor is active");
+	}
+}
+
+/**
+ * @param editor
+ */
+export function toggleLineComment(editor: TextEditor): void {
+	if (editor) {
+		const tagComment: boolean = isTagComment(editor.document, editor.selection.start, undefined);
+		toggleComment(CommentType.Line, editor, tagComment);
+	}
+	else {
+		window.showInformationMessage("No editor is active");
+	}
+}
+
+/**
  * Return a function that can be used to execute a line or block comment
  * @param commentType The comment type for which the command will be executed
- * @param _token
- * @returns
+ * @param editor
+ * @param tagComment
  */
-export function toggleComment(commentType: CommentType, _token: CancellationToken | undefined): (editor: TextEditor) => void {
-	return (editor: TextEditor) => {
-		if (editor) {
-			// const isSingleLine: boolean = (editor.selections.every(selection => selection.isSingleLine) && editor.selections.length === 1);
-			const tagComment: boolean = isTagComment(editor.document, editor.selection.start, _token);
-			if (getCurrentConfigIsTag() !== tagComment) {
-				setCurrentConfigIsTag(tagComment);
-				const languageConfig: LanguageConfiguration = tagComment
-					? {
-							comments: {
-								blockComment: cfmlCommentRules.tagBlockComment,
-							},
-						}
-					: {
-							comments: {
-								lineComment: cfmlCommentRules.scriptLineComment,
-								blockComment: cfmlCommentRules.scriptBlockComment,
-							},
-						};
-				languages.setLanguageConfiguration(LANGUAGE_ID, languageConfig);
-			}
-			const command: string = getCommentCommand(commentType);
-			commands.executeCommand(command);
+export function toggleComment(commentType: CommentType, editor: TextEditor, tagComment: boolean): void {
+	if (editor) {
+		if (getCurrentConfigIsTag() !== tagComment) {
+			setCurrentConfigIsTag(tagComment);
+			const languageConfig: LanguageConfiguration = tagComment
+				? {
+						comments: {
+							blockComment: cfmlCommentRules.tagBlockComment,
+						},
+					}
+				: {
+						comments: {
+							lineComment: cfmlCommentRules.scriptLineComment,
+							blockComment: cfmlCommentRules.scriptBlockComment,
+						},
+					};
+			languages.setLanguageConfiguration(LANGUAGE_ID, languageConfig);
 		}
-		else {
-			window.showInformationMessage("No editor is active");
-		}
-	};
+		const command: string = getCommentCommand(commentType);
+		commands.executeCommand(command);
+	}
+	else {
+		window.showInformationMessage("No editor is active");
+	}
 }


### PR DESCRIPTION
cfscript range calculation is unreliable

It attempts to match the start, end and contents of the cfscript block in one regex, this often fails because
- The `<cfscript>` or `</cfscript>` tags might individually be inside a block comment 
- There might be something in the contents of the `<cfscript>` `</cfscript>` block that causes the content part of the regex to fail
- The regex search might skip over closing `</cfscript>` tags and include it as "contents" of the `<cfscript>` `</cfscript>` block

Other solutions might involve complex look aheads or predicting where content might cause the regex to fail

This solution simply matches start and end tags independently of each other within a loop which can also check if the `<cfscript>` `</cfscript>` tags are inside a tag comment block

On top of this, the logic that checks if the cursor / selection is inside a cfscript block currently includes the cfscript tags themselves, so I have created an option called `excludeTags` that when passed as `true` excludes the cfscript tags from the cfscript ranges.

An simple example of where the current implementation will fail below.

```cfml
<!---
<cfscript>
--->

<cfscript>

	
</cfscript>
```