### PR TITLE
118 sublime toggle comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cfmleditor",
 	"displayName": "CFML Editor",
 	"description": "CFML Language Editor",
-	"version": "0.6.42-beta2",
+	"version": "0.6.42-beta3",
 	"preview": true,
 	"author": "cfmleditor",
 	"publisher": "cfmleditor",

--- a/package.json
+++ b/package.json
@@ -498,6 +498,12 @@
 					"default": "",
 					"markdownDescription": "A subfolder used as the web root by the ColdFusion/Lucee server.\n\nTypically this will be blank, or a subfolder like `public`, `www`, `src`, or wherever the main `Application.cfc` is located.\n\nUse in conjunction with `#cfml.mappings#` to resolve component paths.",
 					"scope": "resource"
+				},
+				"cfml.comments.uncommentAnywhere.enabled": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "A setting to enable uncomment from anywhere within a comment block.",
+					"scope": "resource"
 				}
 			}
 		},

--- a/src/features/comment.ts
+++ b/src/features/comment.ts
@@ -1,9 +1,7 @@
-import { Position, languages, commands, window, TextEditor, LanguageConfiguration, TextDocument, CharacterPair, CancellationToken, Range, Selection } from "vscode";
+import { Position, languages, commands, window, TextEditor, LanguageConfiguration, TextDocument, CharacterPair, CancellationToken, Range, Selection, workspace, WorkspaceConfiguration } from "vscode";
 import { getCurrentConfigIsTag, LANGUAGE_ID, setCurrentConfigIsTag } from "../cfmlMain";
 import { isCfcFile, getTagCommentRanges, isCfsFile, getCfScriptRanges, getScriptCommentRanges } from "../utils/contextUtil";
 import { getComponent, hasComponent } from "./cachedEntities";
-
-const UNCOMMENT_INCOMMENT: boolean = true; // TODO: This should be a setting
 
 export enum CommentType {
 	Line,
@@ -150,8 +148,12 @@ export function toggleComment(commentType: CommentType, editor: TextEditor): voi
 		window.showInformationMessage("No editor is active");
 		return;
 	}
+
+	const cfmlCommentSettings: WorkspaceConfiguration = workspace.getConfiguration("cfml.comments", editor.document.uri);
+	const uncommentAnywhere: boolean = cfmlCommentSettings.get<boolean>("uncommentAnywhere.enabled", false);
+
 	const [lang, range] = getCommentLangAndInRange(editor.document, editor.selection.start, undefined);
-	if (UNCOMMENT_INCOMMENT && editor.selections.length < 2 && range && (lang === CommentLanguage.Tag || editor.document.getText(range).charCodeAt(1) === 42)) { // 47 = '/', 42 = '*'
+	if (uncommentAnywhere && editor.selections.length < 2 && range && (lang === CommentLanguage.Tag || editor.document.getText(range).charCodeAt(1) === 42)) { // 47 = '/', 42 = '*'
 		forceUncommentBlock(
 			editor,
 			range,

--- a/src/utils/contextUtil.ts
+++ b/src/utils/contextUtil.ts
@@ -382,8 +382,7 @@ function getCommentRanges(document: TextDocument, isScript: boolean = false, doc
  * @param _token A cancellation token.
  * @returns An array of comment ranges.
  */
-
-function getScriptCommentRanges(document: TextDocument, docRange: Range | undefined, _token: CancellationToken | undefined): Range[] {
+export function getScriptCommentRanges(document: TextDocument, docRange: Range | undefined, _token: CancellationToken | undefined): Range[] {
 	const commentRanges: Range[] = [];
 	const validRange = docRange && document.validateRange(docRange);
 	const documentText = validRange ? document.getText(docRange) : document.getText();


### PR DESCRIPTION
Where a cursor or selection is made inside an existing block comment, the comment toggle should un-toggle the comment.
- Ensured selection remains consistent after "Uncomment"
- New `Uncomment Anywhere` setting
- Only works with single cursor selection ( not intended for multi cursors )