### PR TITLE
Fixes for #125

### DIFF
--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -102,6 +102,11 @@ const booleanAttributes: MySet<string> = new MySet([
 	"serializable",
 ]);
 
+export interface ComponentRef {
+	uri: Uri;
+	name: string;
+}
+
 export interface Component {
 	uri: Uri;
 	name: string;

--- a/src/entities/userFunction.ts
+++ b/src/entities/userFunction.ts
@@ -124,6 +124,11 @@ export interface UserFunctionSignature extends Signature {
 	parameters: Argument[];
 }
 
+export interface UserFunctionRef {
+	name: string;
+	componenturi: Uri;
+}
+
 export interface UserFunction extends Function {
 	access: Access;
 	static: boolean;


### PR DESCRIPTION
- TrieSearch collections are mostly additive and removing items has its own issues
- Update TrieSearch collections to use a cut down version of the Component and Function interfaces to reduce the overhead of copies of the full objects
- Update to ensure keys used in cachedEntities objects storing components and functions are consistent and reduce repeating the process of converting a Uri to a lowercase string
- Make console.warn messages a bit clearer on which trie object is failing
- Update Trie search functions to return matches based on the results of the TrieSearch and the associated cached object matches
- Ensure cached objects are updated consistently