### PR TITLE
LDEV-1402 add lucee debugger DAP client support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,17 @@
 		"workspaceContains:**/*.cfm",
 		"workspaceContains:**/*.cfml",
 		"workspaceContains:**/*.cfc",
-		"workspaceContains:**/*.cfs"
+		"workspaceContains:**/*.cfs",
+		"onDebugResolve:cfml"
 	],
 	"icon": "images/icon2x.png",
 	"main": "./dist/desktop/extension.js",
 	"browser": "./dist/web/extension.js",
 	"contributes": {
+		"breakpoints": [
+			{ "language": "cfml" },
+			{ "language": "cfs" }
+		],
 		"languages": [
 			{
 				"id": "cfml",
@@ -572,9 +577,67 @@
 				"command": "cfml.goToRouteController",
 				"category": "CFML",
 				"title": "Go to Route Controller"
+			},
+			{
+				"command": "cfml.debug.dump",
+				"category": "CFML",
+				"title": "Dump Variable",
+				"enablement": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'"
+			},
+			{
+				"command": "cfml.debug.dumpAsJSON",
+				"category": "CFML",
+				"title": "Dump Variable as JSON",
+				"enablement": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'"
+			},
+			{
+				"command": "cfml.debug.getMetadata",
+				"category": "CFML",
+				"title": "Get Metadata",
+				"enablement": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'"
+			},
+			{
+				"command": "cfml.debug.getApplicationSettings",
+				"category": "CFML",
+				"title": "Get Application Settings",
+				"enablement": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'"
+			},
+			{
+				"command": "cfml.debug.openSourceFile",
+				"category": "CFML",
+				"title": "Open Defining File",
+				"enablement": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'"
+			},
+			{
+				"command": "cfml.debug.showBreakpointBindings",
+				"category": "CFML",
+				"title": "Show Breakpoint Bindings",
+				"enablement": "config.cfml.engine.name == 'lucee'"
 			}
 		],
 		"menus": {
+			"debug/variables/context": [
+				{
+					"when": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'",
+					"command": "cfml.debug.dump"
+				},
+				{
+					"when": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'",
+					"command": "cfml.debug.dumpAsJSON"
+				},
+				{
+					"when": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'",
+					"command": "cfml.debug.getMetadata"
+				},
+				{
+					"when": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'",
+					"command": "cfml.debug.getApplicationSettings"
+				},
+				{
+					"when": "debugType == 'cfml' && config.cfml.engine.name == 'lucee'",
+					"command": "cfml.debug.openSourceFile"
+				}
+			],
 			"editor/title/context": [
 				{
 					"command": "cfml.copyPackage",
@@ -635,6 +698,141 @@
 					"tag": "<cfdump var=\"$TM_SELECTED_TEXT\">",
 					"script": "writeDump($TM_SELECTED_TEXT)"
 				}
+			}
+		],
+		"debuggers": [
+			{
+				"type": "cfml",
+				"languages": ["cfml", "cfs"],
+				"label": "CFML Debugger",
+				"configurationAttributes": {
+					"attach": {
+						"required": ["hostName", "port"],
+						"properties": {
+							"hostName": {
+								"type": "string",
+								"description": "Hostname or IP address of the server running the Lucee debugger."
+							},
+							"port": {
+								"type": "number",
+								"description": "Port configured to accept debugger connections.",
+								"default": 10000
+							},
+							"pathTransforms": {
+								"type": "array",
+								"description": "Ordered list of path transforms for mapping IDE paths to server webroot paths (e.g. for Docker containers). First match wins. For local development where paths match, leave empty.",
+								"items": {
+									"type": "object",
+									"properties": {
+										"idePrefix": {
+											"type": "string",
+											"default": "${workspaceFolder}"
+										},
+										"serverPrefix": {
+											"type": "string",
+											"default": "${workspaceFolder}"
+										}
+									},
+									"required": ["idePrefix", "serverPrefix"]
+								},
+								"default": []
+							},
+							"pathSeparator": {
+								"type": "string",
+								"enum": ["none", "auto", "posix", "windows"],
+								"default": "auto",
+								"description": "How paths returned from the debugger should be normalized."
+							},
+							"secret": {
+								"type": "string",
+								"description": "Secret that must match LUCEE_DEBUGGER_SECRET environment variable on the server."
+							},
+							"evaluation": {
+								"type": "boolean",
+								"default": true,
+								"description": "Enable expression evaluation in debug console, watch panel, and hover tooltips."
+							},
+							"logLevel": {
+								"type": "string",
+								"enum": ["error", "info", "debug"],
+								"default": "info",
+								"description": "Debugger log verbosity level."
+							},
+							"logColor": {
+								"type": "boolean",
+								"default": true,
+								"description": "Enable ANSI colors in debugger log output."
+							},
+							"logExceptions": {
+								"type": "boolean",
+								"default": false,
+								"description": "Log exceptions to the debug console."
+							},
+							"consoleOutput": {
+								"type": "boolean",
+								"default": false,
+								"description": "Stream console output to the debug console (Lucee 7.1+)."
+							}
+						}
+					}
+				},
+				"initialConfigurations": [
+					{
+						"type": "cfml",
+						"request": "attach",
+						"name": "Attach to Lucee",
+						"hostName": "localhost",
+						"port": 9999,
+						"secret": "",
+						"pathTransforms": [
+							{
+								"idePrefix": "${workspaceFolder}",
+								"serverPrefix": "${workspaceFolder}"
+							}
+						],
+						"pathSeparator": "auto"
+					}
+				],
+				"configurationSnippets": [
+					{
+						"label": "CFML: Attach to Lucee",
+						"description": "Attach to Lucee debugger (local development)",
+						"body": {
+							"type": "cfml",
+							"request": "attach",
+							"name": "Attach to Lucee",
+							"hostName": "localhost",
+							"port": 9999,
+							"secret": "",
+							"pathTransforms": [
+								{
+									"idePrefix": "\\${workspaceFolder}",
+									"serverPrefix": "\\${workspaceFolder}"
+								}
+							],
+							"pathSeparator": "auto"
+						}
+					},
+					{
+						"label": "CFML: Attach to Lucee (Docker)",
+						"description": "Attach to Lucee debugger in Docker container",
+						"body": {
+							"type": "cfml",
+							"request": "attach",
+							"name": "Attach to Lucee (Docker)",
+							"hostName": "localhost",
+							"port": 9999,
+							"secret": "",
+							"pathTransforms": [
+								{
+									"idePrefix": "\\${workspaceFolder}",
+									"serverPrefix": "/var/www"
+								}
+							],
+							"pathSeparator": "posix"
+						}
+					}
+				]
 			}
 		]
 	},

--- a/src/cfmlMain.ts
+++ b/src/cfmlMain.ts
@@ -20,6 +20,7 @@ import CFMLWorkspaceSymbolProvider from "./features/workspaceSymbolProvider";
 import CFDocsService from "./utils/cfdocs/cfDocsService";
 import { APPLICATION_CFM_GLOB, isApplicationFile, isCfcUri, shouldExcludeDocument } from "./utils/contextUtil";
 import { handleContentChanges } from "./features/autoclose";
+import { registerDebugAdapter } from "./features/debugAdapter";
 // import { CFMLFlatPackageProvider } from "./views/components";
 
 export const LANGUAGE_ID: string = "cfml";
@@ -144,6 +145,9 @@ export async function activate(context: ExtensionContext): Promise<api> {
 	context.subscriptions.push(languages.registerDefinitionProvider(DOCUMENT_SELECTOR, new CFMLDefinitionProvider()));
 	context.subscriptions.push(languages.registerTypeDefinitionProvider(DOCUMENT_SELECTOR, new CFMLTypeDefinitionProvider()));
 	context.subscriptions.push(languages.registerColorProvider(DOCUMENT_SELECTOR, new CFMLDocumentColorProvider()));
+
+	// Register debug adapter
+	registerDebugAdapter(context);
 
 	context.subscriptions.push(workspace.onDidSaveTextDocument(async (document: TextDocument) => {
 		if (!document || shouldExcludeDocument(document.uri)) {

--- a/src/features/debugAdapter.ts
+++ b/src/features/debugAdapter.ts
@@ -1,0 +1,352 @@
+import {
+	commands,
+	debug,
+	DebugAdapterDescriptor,
+	DebugAdapterDescriptorFactory,
+	DebugAdapterServer,
+	DebugSession,
+	EventEmitter,
+	ExtensionContext,
+	languages,
+	ProviderResult,
+	TextDocumentContentProvider,
+	Uri,
+	window,
+	workspace,
+	EvaluatableExpression,
+	EvaluatableExpressionProvider,
+	Position,
+	TextDocument,
+	CancellationToken,
+	WebviewPanel,
+	ViewColumn,
+} from "vscode";
+
+let currentDebugSession: DebugSession | null = null;
+
+interface DebugPaneContextMenuArgs {
+	container: {
+		expensive: boolean;
+		name: string;
+		variablesReference: number;
+	};
+	sessionId: string;
+	variable: {
+		name: string;
+		value: string;
+		variablesReference: number;
+	};
+}
+
+interface DumpResponse {
+	content: string;
+}
+
+interface DebugBreakpointBindingsResponse {
+	canonicalFilenames: string[];
+	breakpoints: [string, string][];
+	pathTransforms: string[];
+}
+
+interface GetSourcePathResponse {
+	path: string | null;
+}
+
+class CfmlDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
+	createDebugAdapterDescriptor(session: DebugSession): ProviderResult<DebugAdapterDescriptor> {
+		currentDebugSession = session;
+
+		const host = session.configuration.hostName as string;
+		const port = parseInt(session.configuration.port);
+
+		return new DebugAdapterServer(port, host);
+	}
+}
+
+class CfmlDebugTextDocumentProvider implements TextDocumentContentProvider {
+	private docs: { [uri: string]: string } = {};
+	private onDidChangeEmitter = new EventEmitter<Uri>();
+	onDidChange = this.onDidChangeEmitter.event;
+
+	addOrReplaceTextDoc(uri: Uri, text: string): void {
+		this.docs[uri.toString()] = text;
+		this.onDidChangeEmitter.fire(uri);
+	}
+
+	provideTextDocumentContent(uri: Uri): ProviderResult<string> {
+		return this.docs[uri.toString()] ?? null;
+	}
+}
+
+class CfmlEvaluatableExpressionProvider implements EvaluatableExpressionProvider {
+	provideEvaluatableExpression(document: TextDocument, position: Position, _token: CancellationToken): ProviderResult<EvaluatableExpression> {
+		// Match most variable declaration styles:
+		// local.varName, varName, local.varName.subKey, local.varName['subKey'],
+		// local['varName'].subKey, local['varName'][subKey], local.varName["subKey"]
+		const varRange = document.getWordRangeAtPosition(position, /[\w_][\w\[\]"'._-]+[\w\]]/ig)
+			?? document.getWordRangeAtPosition(position);
+
+		if (varRange !== undefined) {
+			return new EvaluatableExpression(varRange);
+		}
+		return undefined;
+	}
+}
+
+const webviewPanelByUri: { [uri: string]: WebviewPanel } = {};
+
+function updateOrCreateWebview(uri: Uri, html: string): void {
+	const uriString = uri.toString();
+	const panel = webviewPanelByUri[uriString];
+
+	if (panel) {
+		panel.webview.html = html;
+		panel.reveal(undefined, true);
+	}
+	else {
+		const newPanel = window.createWebviewPanel(
+			"cfml-debug",
+			uri.path,
+			ViewColumn.One,
+			{ enableScripts: true }
+		);
+		newPanel.webview.html = html;
+		webviewPanelByUri[uriString] = newPanel;
+		newPanel.onDidDispose(() => {
+			delete webviewPanelByUri[uriString];
+		});
+	}
+}
+
+function normalizePathFromSession(session: DebugSession, path: string): string {
+	const pathSeparator = session.configuration?.pathSeparator ?? "auto";
+	if (pathSeparator === "none") return path;
+
+	const platformDefault = process.platform === "win32" ? "\\" : "/";
+	const normalizedSeparator = pathSeparator === "posix"
+		? "/"
+		: pathSeparator === "windows"
+			? "\\"
+			: platformDefault;
+
+	return path.replace(/[\\/]/g, normalizedSeparator);
+}
+
+export function registerDebugAdapter(context: ExtensionContext): void {
+	const outputChannel = window.createOutputChannel("CFML Debugger");
+	const textDocumentProvider = new CfmlDebugTextDocumentProvider();
+
+	context.subscriptions.push(outputChannel);
+	context.subscriptions.push(debug.registerDebugAdapterDescriptorFactory("cfml", new CfmlDebugAdapterDescriptorFactory()));
+	context.subscriptions.push(workspace.registerTextDocumentContentProvider("cfml-debug", textDocumentProvider));
+	context.subscriptions.push(languages.registerEvaluatableExpressionProvider("cfml", new CfmlEvaluatableExpressionProvider()));
+	context.subscriptions.push(languages.registerEvaluatableExpressionProvider("cfs", new CfmlEvaluatableExpressionProvider()));
+
+	// Dump variable as HTML
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.dump", async (args?: Partial<DebugPaneContextMenuArgs>) => {
+			if (!currentDebugSession || args?.variable === undefined || args.variable.variablesReference === 0) {
+				return;
+			}
+
+			const result: DumpResponse = await currentDebugSession.customRequest("dump", {
+				variablesReference: args.variable.variablesReference
+			});
+
+			const uri = Uri.from({
+				scheme: "cfml-debug",
+				path: args.variable.name,
+				fragment: args.variable.variablesReference.toString()
+			});
+
+			updateOrCreateWebview(uri, result.content);
+		})
+	);
+
+	// Dump variable as JSON
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.dumpAsJSON", async (args?: Partial<DebugPaneContextMenuArgs>) => {
+			if (!currentDebugSession || args?.variable === undefined || args.variable.variablesReference === 0) {
+				return;
+			}
+
+			const result: DumpResponse = await currentDebugSession.customRequest("dumpAsJSON", {
+				variablesReference: args.variable.variablesReference
+			});
+
+			let obj: unknown;
+			try {
+				obj = JSON.parse(result.content);
+			}
+			catch {
+				obj = "Failed to parse the following JSON:\n" + result.content;
+			}
+
+			const uri = Uri.from({
+				scheme: "cfml-debug",
+				path: args.variable.name,
+				fragment: args.variable.variablesReference.toString()
+			});
+			const text = JSON.stringify(obj, undefined, 4);
+
+			textDocumentProvider.addOrReplaceTextDoc(uri, text);
+
+			const doc = await workspace.openTextDocument(uri);
+			await window.showTextDocument(doc);
+		})
+	);
+
+	// Get metadata for variable
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.getMetadata", async (args?: Partial<DebugPaneContextMenuArgs>) => {
+			if (!currentDebugSession || args?.variable === undefined || args.variable.variablesReference === 0) {
+				return;
+			}
+
+			const result: DumpResponse = await currentDebugSession.customRequest("getMetadata", {
+				variablesReference: args.variable.variablesReference
+			});
+
+			let obj: unknown;
+			try {
+				obj = JSON.parse(result.content);
+			}
+			catch {
+				obj = "Failed to parse the following JSON:\n" + result.content;
+			}
+
+			const uri = Uri.from({
+				scheme: "cfml-debug",
+				path: args.variable.name + ".metadata",
+				fragment: args.variable.variablesReference.toString()
+			});
+			const text = JSON.stringify(obj, undefined, 4);
+
+			textDocumentProvider.addOrReplaceTextDoc(uri, text);
+
+			const doc = await workspace.openTextDocument(uri);
+			await window.showTextDocument(doc);
+		})
+	);
+
+	// Get application settings
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.getApplicationSettings", async (args?: Partial<DebugPaneContextMenuArgs>) => {
+			if (!currentDebugSession) {
+				return;
+			}
+
+			// Only allow for the top-level application scope
+			if (!args?.container || args.container.name !== "application") {
+				window.showWarningMessage("Get Application Settings is only available for the top-level application scope");
+				return;
+			}
+
+			const result: DumpResponse = await currentDebugSession.customRequest("getApplicationSettings", {
+				variablesReference: args.container.variablesReference
+			});
+
+			let obj: unknown;
+			try {
+				obj = JSON.parse(result.content);
+			}
+			catch {
+				obj = "Failed to parse the following JSON:\n" + result.content;
+			}
+
+			const uri = Uri.from({
+				scheme: "cfml-debug",
+				path: "applicationSettings",
+				fragment: Date.now().toString()
+			});
+			const text = JSON.stringify(obj, undefined, 4);
+
+			textDocumentProvider.addOrReplaceTextDoc(uri, text);
+
+			const doc = await workspace.openTextDocument(uri);
+			await window.showTextDocument(doc);
+		})
+	);
+
+	// Open source file for variable
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.openSourceFile", async (args?: Partial<DebugPaneContextMenuArgs>) => {
+			if (!currentDebugSession || !args || args.variable === undefined || args.variable.variablesReference === 0) {
+				return;
+			}
+
+			const data: GetSourcePathResponse = await currentDebugSession.customRequest("getSourcePath", {
+				variablesReference: args.variable.variablesReference
+			});
+
+			if (!data.path) {
+				return;
+			}
+
+			const uri = Uri.from({ scheme: "file", path: data.path });
+			const doc = await workspace.openTextDocument(uri);
+			await window.showTextDocument(doc);
+		})
+	);
+
+	// Show breakpoint bindings (debug info)
+	context.subscriptions.push(
+		commands.registerCommand("cfml.debug.showBreakpointBindings", async () => {
+			if (!currentDebugSession) {
+				throw Error("CFML debugger is not currently connected, cannot show breakpoint bindings.");
+			}
+
+			const data: DebugBreakpointBindingsResponse = await currentDebugSession.customRequest("debugBreakpointBindings");
+
+			const uri = Uri.from({ scheme: "cfml-debug", path: "breakpointBindings" });
+			const text = "Breakpoints the debugger has:\n"
+				+ data.breakpoints
+					.sort(([l_idePath], [r_idePath]) => l_idePath < r_idePath ? -1 : 1)
+					.map(([idePath, serverPath]) => `  (ide)    ${idePath}\n  (server) ${serverPath}`)
+					.join("\n\n")
+				+ "\n\nPath transforms:\n"
+				+ (data.pathTransforms.length === 0 ? "  <<none>>" : data.pathTransforms.map(v => `  ${v}`).join("\n"))
+				+ "\n\nFiles the debugger knows about (all filenames are as the server sees them, and match against breakpoint 'server' paths):\n"
+				+ data.canonicalFilenames.sort().map(s => `  ${s}`).join("\n");
+
+			textDocumentProvider.addOrReplaceTextDoc(uri, text);
+
+			const doc = await workspace.openTextDocument(uri);
+			await window.showTextDocument(doc);
+		})
+	);
+
+	// Debug adapter tracker for logging DAP messages
+	context.subscriptions.push(
+		debug.registerDebugAdapterTrackerFactory("cfml", {
+			createDebugAdapterTracker(session: DebugSession) {
+				return {
+					onWillReceiveMessage(message: unknown): void {
+						outputChannel.appendLine(JSON.stringify(message, null, 4));
+					},
+					onDidSendMessage(message: unknown): void {
+						// Normalize paths in stack trace responses
+						const msg = message as { command?: string; type?: string; body?: { stackFrames?: Array<{ source?: { path?: string } }> } };
+						if (msg.command === "stackTrace" || (msg.type === "response" && msg.body?.stackFrames)) {
+							for (const frame of msg.body?.stackFrames ?? []) {
+								if (frame.source?.path) {
+									frame.source.path = normalizePathFromSession(session, frame.source.path);
+								}
+							}
+						}
+						outputChannel.appendLine(JSON.stringify(message, null, 4));
+					}
+				};
+			}
+		})
+	);
+
+	// Clear session on debug stop
+	context.subscriptions.push(
+		debug.onDidTerminateDebugSession((session) => {
+			if (session === currentDebugSession) {
+				currentDebugSession = null;
+			}
+		})
+	);
+}


### PR DESCRIPTION
This adds support for luceeDebug, both for the current agent version and the new native debugger support coming in Lucee 7.1

https://luceeserver.atlassian.net/browse/LDEV-1402

Based on https://github.com/softwareCobbler/luceedebug VS Code client

https://marketplace.visualstudio.com/items?itemName=DavidRogers.luceedebug

The author David Rodgers of Luceedebug has given permission to fork